### PR TITLE
Fix project name reference in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,37 +1,40 @@
 # Contributing to Furnix.
 
-First off, thank you for considering contributing to **DineFit**!
-Your help makes this project better for everyone.  
+First off, thank you for considering contributing to **Furnix**!
+Your help makes this project better for everyone.
 
 ## How Can You Contribute?
 
 ### 🐛 Reporting Bugs
-- Check the [issues](../../issues) to see if the bug has already been reported.  
-- Open a new issue with:  
-  - A clear description of the bug  
-  - Steps to reproduce  
-  - Expected vs actual behavior  
-  - Screenshots/logs will be helpful  
+
+- Check the [issues](../../issues) to see if the bug has already been reported.
+- Open a new issue with:
+  - A clear description of the bug
+  - Steps to reproduce
+  - Expected vs actual behavior
+  - Screenshots/logs will be helpful
 
 ### 💡 Suggesting Features
-- Open an issue and label it as a **feature request**.  
-- Clearly explain the problem the feature solves.  
+
+- Open an issue and label it as a **feature request**.
+- Clearly explain the problem the feature solves.
 - Suggest a possible implementation (if you have one).
 
 ### Project Setup Guide
+
 1. **Fork the repository**
 
-2. **Create a feature branch**  
+2. **Create a feature branch**
    ```bash
    git checkout -b feature/your-feature-name
    ```
-3. **Make your changes**  
-   - Follow the project’s coding style.  
-   - Write clear, self-explanatory commits.  
+3. **Make your changes**
+   - Follow the project’s coding style.
+   - Write clear, self-explanatory commits.
 
-4. **Add tests (if applicable)**  
+4. **Add tests (if applicable)**
 
-5. **Commit your changes**  
+5. **Commit your changes**
    ```bash
    git commit -m "Add feature: description"
    ```
@@ -42,16 +45,17 @@ Your help makes this project better for everyone.
 7. **Open a Pull Request**
    - Describe what you changed and why.
    - Reference any related issues.
-  
+
 ### Code Style
+
 - Use clear and consistent naming conventions.
 - Keep functions small and focused.
 - Write comments where needed.
 
 ### ✅ Pull Request Checklist
+
 - I updated relevant documentation (if needed)
 - I linked the PR to any relevant issues
-
 
 ### Legal / License
 


### PR DESCRIPTION
## **Description**
This PR fixes an inconsistency in the CONTRIBUTING.md file.

### **Issue**
The contribution guide is intended for Furnix, but the introductory paragraph incorrectly referenced "DineFit", which appears to be a leftover reference from another project.

### **Changes Made**
* Replaced "DineFit" with "**Furnix**" in the introductory paragraph of CONTRIBUTING.md.

### Result
The contribution guide now consistently references Furnix throughout the document.

Fixes #69
