### PR TITLE
feat: add CTA buttons to empty cart and wishlist pages

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -90,6 +90,8 @@
                 <div class="cart-empty-state" id="cartEmptyState">
                     <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                     <h3>Your cart is empty</h3>
+                    <p class="detail-info-platform" style="margin: 0 auto 1.5rem auto; text-align: center;">Explore our premium furniture collection and add items to your cart.</p>
+                    <a href="collections.html" class="btn btn-inline">Shop Collections</a>
                 </div>
 
                 <div class="cart-layout" id="cartLayout">

--- a/wishlist.html
+++ b/wishlist.html
@@ -64,6 +64,8 @@
                 <div class="wishlist-empty-state" id="wishlistEmptyState">
                     <i class="fa-solid fa-heart" aria-hidden="true"></i>
                     <h3>Your wishlist is empty</h3>
+                    <p class="detail-info-platform" style="margin: 0 auto 1.5rem auto; text-align: center;">Save your favorite contemporary items here for later.</p>
+                    <a href="furniture.html" class="btn btn-inline">Browse Furniture</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Closes #97 

# Problem
When the shopping cart or wishlist is empty, the pages display a static notice without any redirection links, creating a dead-end for users.

# Root Cause
Empty state blocks lack CTA links to return to the catalog pages.

# Solution
Added descriptive call-to-action buttons ("Shop Collections", "Browse Furniture") to guide users back to the product catalog.

# Changes Made
* Appended description text and a "Shop Collections" CTA button to `#cartEmptyState` in `cart.html`.
* Appended description text and a "Browse Furniture" CTA button to `#wishlistEmptyState` in `wishlist.html`.

# Testing
* Emptied the cart/wishlist and verified the call-to-action buttons render and redirect correctly.

# Impact
Improves user retention and conversion rates.

# Risks
None.
