### PR TITLE
fix: sync cart and wishlist page state across multiple tabs

### DIFF
--- a/app.js
+++ b/app.js
@@ -528,6 +528,13 @@ if (searchIcon) {
 
 // ✅ Real-time badge sync across all pages without refresh
 window.addEventListener('storage', (e) => {
-    if (e.key === CART_KEY) updateCartBadge();
-    if (e.key === WISHLIST_KEY) updateWishlistBadge();
+    if (e.key === CART_KEY) {
+        updateCartBadge();
+        renderCartPage();
+        if (typeof renderCheckoutSummary === 'function') renderCheckoutSummary();
+    }
+    if (e.key === WISHLIST_KEY) {
+        updateWishlistBadge();
+        renderWishlistPage();
+    }
 });


### PR DESCRIPTION
Closes #99 

# Problem
If a user edits their cart or wishlist in one tab, the cart items list in another open tab remains out of sync, allowing the user to complete checkout with incorrect totals.

# Root Cause
The storage event listener in `app.js` only updates the badges, missing the main page container re-renders.

# Solution
Extended the storage event listener to trigger UI re-renders on active cart/wishlist templates when storage updates.

# Changes Made
* Updated storage event listener in `app.js` (line 528).
* Added conditional execution of `renderCartPage()`, `renderCheckoutSummary()`, and `renderWishlistPage()` on storage updates.

# Testing
* Opened two browser tabs side-by-side.
* Deleted an item in tab A and verified that tab B updated its cart layout and summary totals instantly.

# Impact
Prevents out-of-sync checkouts across multiple open tabs.

# Risks
None.
