### PR TITLE
perf: prevent layout shifts by defining image dimensions

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,7 +163,7 @@ function renderCartPage() {
         card.classList.add('cart-item-card');
         card.innerHTML = `
             <div class="cart-item-image">
-                <img src="${item.image}" alt="${item.name}">
+                <img src="${item.image}" alt="${item.name}" width="100" height="100" loading="lazy">
             </div>
             <div class="cart-item-details">
                 <p class="cart-item-category">${item.category || 'Furniture'}</p>

--- a/search.html
+++ b/search.html
@@ -224,7 +224,7 @@
                 return `
                     <div class="product-card" data-product-id="${p.id}">
                         <div class="product-image">
-                            <img src="${p.image}" alt="${p.name}" loading="lazy">
+                            <img src="${p.image}" alt="${p.name}" width="300" height="300" loading="lazy">
                             <a href="#" class="favorite-icon" aria-label="Add to wishlist">
                                 <i class="${heartClass} fa-heart" ${heartColor}></i>
                             </a>


### PR DESCRIPTION
# Related Issue
Closes #101 

# Problem
Images dynamically rendered in the cart and search pages lack explicit height/width dimensions, causing visual layout shifts as they load.

# Root Cause
Image tags generated in JavaScript omit dimensions and native lazy loading attributes.

# Solution
Added explicit dimensions and enabled native lazy loading on dynamic images.

# Changes Made
* Updated dynamic `<img>` tag in `app.js` (cart render) with `width="100" height="100" loading="lazy"`.
* Updated search result images in `search.html` with `width="300" height="300" loading="lazy"`.

# Testing
* Checked the Network tab to confirm images load lazily on scroll.
* Verified layout remains stable without shifts during image loading.

# Impact
Stabilizes page layout and improves Cumulative Layout Shift (CLS) scores.

# Risks
None.
