### PR TITLE
seo: add unique page titles and descriptions to subpages

### DIFF
--- a/collections.html
+++ b/collections.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Shop Furnix modern furniture, lighting, decor, and handcrafted pieces designed for comfortable contemporary homes.">
-    <title>Furnix Collections</title>
+    <meta name="description" content="Browse our curated design collections including modern seating, architectural lighting, solid wood dining tables, and premium home decor.">
+    <title>Furnix Curated Collections</title>
 
     <!-- CSS LINK -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Shop Furnix modern furniture, lighting, decor, and handcrafted pieces designed for comfortable contemporary homes.">
-    <title>Furniture Website</title>
+    <meta name="description" content="Explore Furnix Neon - Sleek and modern neon-inspired furniture collections. Buy premium couches, lighting, tables, and home accessories.">
+    <title>Furnix Neon - Modern Furniture E-Commerce</title>
 
     <!-- CSS LINK -->
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/search.html
+++ b/search.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Search the Furnix product catalog to find contemporary furniture, beds, accent lamps, and decorative vases for your home.">
     <title>Furnix - Search Products</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">


### PR DESCRIPTION
# Related Issue
Closes #103

# Problem
All inner pages use generic, duplicate title tags and lack unique meta descriptions, which negatively affects search engine optimization (SEO) indexing.

# Root Cause
Missing page-specific SEO headers in static page templates.

# Solution
Added unique title configurations and metadata descriptions to match each subpage's content.

# Changes Made
* Modified `search.html` head to insert meta description.
* Refactored meta tags in `index.html` and `collections.html` to be unique and descriptive.

# Testing
* Audited page headers using Chrome DevTools.
* Confirmed the pages contain unique title tags and meta descriptions.

# Impact
Improves search visibility and click-through rates.

# Risks
None.
