### PR TITLE
fix: safeguard localStorage operations with try-catch blocks for private browsing compatibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,13 +32,25 @@ document.addEventListener('keydown', (e) => {
 const CART_KEY = 'furnix_shopping_cart';
 const WISHLIST_KEY = 'furnix_wishlist';
 
+const memoryStore = {};
+
 function getStorageData(key) {
-    const data = localStorage.getItem(key);
-    return data ? JSON.parse(data) : [];
+    try {
+        const data = localStorage.getItem(key);
+        return data ? JSON.parse(data) : [];
+    } catch (e) {
+        console.warn('LocalStorage blocked, falling back to memory store:', e);
+        return memoryStore[key] || [];
+    }
 }
 
 function setStorageData(key, data) {
-    localStorage.setItem(key, JSON.stringify(data));
+    try {
+        localStorage.setItem(key, JSON.stringify(data));
+    } catch (e) {
+        console.warn('LocalStorage blocked, falling back to memory store:', e);
+        memoryStore[key] = data;
+    }
 }
 
 function getCart() {

--- a/search.html
+++ b/search.html
@@ -143,8 +143,13 @@
 
         // Helper: get wishlist from localStorage (using existing function from app.js)
         function getWishlist() {
-            const data = localStorage.getItem('furnix_wishlist');
-            return data ? JSON.parse(data) : [];
+            try {
+                const data = localStorage.getItem('furnix_wishlist');
+                return data ? JSON.parse(data) : [];
+            } catch (e) {
+                console.warn('LocalStorage blocked:', e);
+                return [];
+            }
         }
 
         // Helper: check if product is in wishlist


### PR DESCRIPTION
# Related Issue
Closes #107 

# Problem
In private browsing mode (Incognito) or under strict privacy settings, the browser blocks access to `localStorage`, causing the application to crash on launch.

# Root Cause
Direct unshielded reads and writes to `localStorage` throw SecurityError exceptions.

# Solution
Wrapped all `localStorage` access helpers in try-catch statements and implemented an in-memory fallback.

# Changes Made
* Added `memoryStore` object fallback in `app.js`.
* Wrapped `getStorageData` and `setStorageData` in try-catch blocks.
* Wrapped `getWishlist` inside `search.html` in try-catch blocks.

# Testing
* Blocked local storage permissions in browser settings.
* Confirmed that cart/wishlist features fallback to memory without throwing console exceptions.

# Impact
Prevents app crashes in private browsing environments.

# Risks
None.
