### PR TITLE
feat: add skeleton loading states and order confirmation details

### DIFF
--- a/app.js
+++ b/app.js
@@ -339,6 +339,17 @@ if (placeOrderBtn) {
             }
         }
 
+        const orderRef = 'FNX-' + Math.floor(100000 + Math.random() * 900000) + '-' + Math.random().toString(36).substr(2, 4).toUpperCase();
+        const deliveryOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+        const deliveryDate = new Date();
+        deliveryDate.setDate(deliveryDate.getDate() + 5);
+        const deliveryStr = deliveryDate.toLocaleDateString('en-US', deliveryOptions);
+
+        const refEl = document.getElementById('successOrderRef');
+        const delEl = document.getElementById('deliveryDate');
+        if (refEl) refEl.innerText = orderRef;
+        if (delEl) delEl.innerText = deliveryStr;
+
         localStorage.removeItem(CART_KEY);
         updateCartBadge();
 

--- a/cart.html
+++ b/cart.html
@@ -20,6 +20,10 @@
                 <i class="fa-solid fa-circle-check" aria-hidden="true"></i>
             </div>
             <h3>Order Placed Successfully!</h3>
+            <div style="margin: 1.5rem 0; padding: 1rem; background: #fafafa; border-radius: 0.5rem; border: 1px dashed #ddd; text-align: left;">
+                <p style="margin: 0 0 0.5rem 0; font-size: 0.95rem; color: #555;"><strong>Order Ref:</strong> <span id="successOrderRef" style="font-family: monospace; color: var(--antique-brown); font-weight: bold;">-</span></p>
+                <p style="margin: 0; font-size: 0.95rem; color: #555;"><strong>Estimated Delivery:</strong> <span id="deliveryDate" style="color: #333;">-</span></p>
+            </div>
             <p class="detail-info-platform">Thank you for shopping with Furnix. We will send you a confirmation and delivery update shortly.</p>
             <a href="index.html" class="btn btn-inline">Back to Home</a>
         </div>


### PR DESCRIPTION
# Related Issue
Closes #109 

# Problem
The successful checkout modal screen displays a generic static success message without showing an order reference number or delivery estimates, which makes the checkout experience feel unpolished.

# Root Cause
The success overlay template does not include dynamic metadata placeholders.

# Solution
Generated unique reference codes and estimated delivery windows on checkout success, rendering them directly in the overlay.

# Changes Made
* Added reference ID and delivery date placeholders inside `#successOverlay` in `cart.html`.
* Updated checkout validation success block in `app.js` to generate order ID string (e.g. `FNX-491023-ABCD`) and date offset (+5 days).

# Testing
* Checked out with mock cart items, verified unique order ID is generated and displayed in the modal.

# Impact
Provides reassurance to users with a clear checkout confirmation step.

# Risks
None.
