### PR TITLE
fix: resolve duplicate DOM ID violations across all footer components

### DIFF
--- a/Lighting.html
+++ b/Lighting.html
@@ -180,7 +180,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/about.html
+++ b/about.html
@@ -137,7 +137,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">
@@ -186,3 +186,4 @@
     <script src="app.js"></script>
 </body>
 </html>
+

--- a/accessories .html
+++ b/accessories .html
@@ -177,7 +177,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/cart.html
+++ b/cart.html
@@ -252,7 +252,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/collections.html
+++ b/collections.html
@@ -139,7 +139,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/contact.html
+++ b/contact.html
@@ -126,7 +126,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/designers.html
+++ b/designers.html
@@ -136,7 +136,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/faq.html
+++ b/faq.html
@@ -99,7 +99,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/furniture.html
+++ b/furniture.html
@@ -245,7 +245,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">
@@ -474,3 +474,4 @@
 </body>
 
 </html>
+

--- a/journal.html
+++ b/journal.html
@@ -116,7 +116,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/search.html
+++ b/search.html
@@ -82,7 +82,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/seating.html
+++ b/seating.html
@@ -178,7 +178,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/story.html
+++ b/story.html
@@ -103,7 +103,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/tabels.html
+++ b/tabels.html
@@ -163,7 +163,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/trends.html
+++ b/trends.html
@@ -114,7 +114,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">

--- a/wishlist.html
+++ b/wishlist.html
@@ -75,7 +75,7 @@
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
                 <div class="input-container">
-                    <input type="email" name="email" id="email" placeholder="Enter your email.." autocomplete="off">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off">
                     <a href="#" class="simple-icon" aria-label="Open details"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></a>
                 </div>
                 <ul class="footer-social-icon flex">


### PR DESCRIPTION
# Related Issue
Closes #111 

# Problem
The DOM ID `#email` is duplicated across footer components and input fields on pages like `contact.html` and `cart.html`, violating W3C markup specifications.

# Root Cause
Copy-pasting the email newsletter input markup without renaming the ID attribute.

# Solution
Renamed the footer email signup element ID to `#footerEmail` globally.

# Changes Made
* Modified all HTML files to replace `id="email"` with `id="footerEmail"` inside the footer signup container.

# Testing
* Checked HTML compliance with an offline validator.
* Verified that signup styling remains intact.

# Impact
Resolves W3C layout standard violations and prevents form field conflicts.

# Risks
None.
