### PR TITLE
accessibility: trap keyboard focus inside active mobile nav drawer

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,9 @@ if (menuBtn && navList) {
         navList.classList.add('navList-active');
         navList.setAttribute('aria-hidden', 'false');
         menuBtn.setAttribute('aria-expanded', 'true');
+        setTimeout(() => {
+            if (navClose) navClose.focus();
+        }, 100);
     });
 }
 
@@ -28,6 +31,28 @@ document.addEventListener('keydown', (e) => {
         if (menuBtn) menuBtn.focus();
     }
 });
+
+if (navList) {
+    navList.addEventListener('keydown', (e) => {
+        if (e.key !== 'Tab') return;
+        const focusableElements = navList.querySelectorAll('a, button');
+        if (focusableElements.length === 0) return;
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) { // Shift + Tab
+            if (document.activeElement === firstElement) {
+                lastElement.focus();
+                e.preventDefault();
+            }
+        } else { // Tab
+            if (document.activeElement === lastElement) {
+                firstElement.focus();
+                e.preventDefault();
+            }
+        }
+    });
+}
 
 const CART_KEY = 'furnix_shopping_cart';
 const WISHLIST_KEY = 'furnix_wishlist';


### PR DESCRIPTION
# Related Issue
Closes #113 

# Problem
Keyboard-only users can navigate outside the open mobile drawer menu using the Tab key, causing them to lose track of the visual focus indicator.

# Root Cause
Lack of focus boundaries inside the menu drawer element.

# Solution
Implemented focus trapping logic to keep keyboard focus confined within the active drawer elements.

# Changes Made
* Added keydown event listeners to `navList` in `app.js` to intercept Tab keys.
* Managed focus rotation between the close button and the last navigation link.
* Added focus auto-triggering to the close button on drawer opening.

# Testing
* Opened drawer using keyboard navigation, pressed Tab and Shift+Tab repeatedly.
* Verified focus remains trapped inside the drawer and wraps correctly.

# Impact
Brings the mobile drawer into compliance with WCAG A11y standards.

# Risks
None.
