### PR TITLE
fix: improve card formatting input UX

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,15 +298,25 @@ document.querySelectorAll('input[name="payment"]').forEach(radio => {
 
 const cardNumberInput = document.getElementById('cardNumber');
 if (cardNumberInput) {
-    cardNumberInput.addEventListener('input', function () {
+    cardNumberInput.addEventListener('input', function (e) {
+        let position = this.selectionEnd;
+        let length = this.value.length;
         this.value = this.value.replace(/\D/g, '').replace(/(.{4})/g, '$1 ').trim();
+        let newLength = this.value.length;
+        position = position + (newLength - length);
+        this.setSelectionRange(position, position);
     });
 }
 
 const cardExpiryInput = document.getElementById('cardExpiry');
 if (cardExpiryInput) {
-    cardExpiryInput.addEventListener('input', function () {
+    cardExpiryInput.addEventListener('input', function (e) {
+        let position = this.selectionEnd;
+        let length = this.value.length;
         this.value = this.value.replace(/\D/g, '').replace(/(\d{2})(\d)/, '$1 / $2');
+        let newLength = this.value.length;
+        position = position + (newLength - length);
+        this.setSelectionRange(position, position);
     });
 }
 


### PR DESCRIPTION
# Related Issue
Closes #115 

# Problem
When entering a credit card number or expiry date on checkout, correcting typos in the middle of the field causes the cursor to jump to the end of the input, disrupting text entry.

# Root Cause
The input listener updates the field's `.value` directly, which resets the selection range and moves the cursor to the end.

# Solution
Calculated the cursor offset before re-formatting and restored it immediately after updating the value.

# Changes Made
* Refactored `cardNumberInput` and `cardExpiryInput` event listeners in `app.js` (line 299) to track cursor positions and adjust selection ranges.

# Testing
* Typed card digits, placed the cursor in the middle, and pressed backspace.
* Verified that character deletions execute cleanly and the cursor position is preserved.

# Impact
Provides a smoother and less frustrating checkout experience.

# Risks
None.
