### PR TITLE
Add image zoom and overlay hover effect on product cards

### DIFF
--- a/style.css
+++ b/style.css
@@ -549,6 +549,27 @@ del {
     object-position: center;
     padding: 1.5rem;
 }
+/* Product image hover effect — zoom + dark overlay */
+.product-image img {
+    transition: transform 0.4s ease;
+}
+
+.product-card:hover .product-image img {
+    transform: scale(1.08);
+}
+
+.product-image::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0);
+    transition: background 0.3s ease;
+    pointer-events: none;
+}
+
+.product-card:hover .product-image::after {
+    background: rgba(0, 0, 0, 0.15);
+}
 
 small {
     font-size: 0.7rem;


### PR DESCRIPTION
Closes #125

## Description
Currently, the product cards had a slide-up "Add to cart" button on hover, but lacked any visual feedback on the image itself. This PR completes the hover experience requested in the issue by adding an image zoom and dark overlay effect.

## Changes
- Product image scales slightly (1.08x) on card hover for a subtle zoom effect
- A dark overlay (15% opacity) fades in smoothly over the image on hover
- Existing "Add to cart" button and wishlist icon functionality untouched
- No backend changes ,  pure CSS, frontend only

## Screen Recording
A screen recording is attached below showing the hover effect in action , image zoom, overlay fade-in, and the existing Add to Cart button sliding up together for a polished interaction.


https://github.com/user-attachments/assets/bd3cbf29-1aff-4bd2-b0c3-5d423df47c28




## Testing
- Tested on Chrome and Firefox
- Verified favorite icon and Add to cart button remain clickable (overlay 
  uses pointer-events: none so it doesn't block interactions)
- Checked on mobile viewport , no layout breakage

## Checklist
- [x] I have followed the contributing guidelines
- [x] My code follows the existing code style
- [x] I have tested my changes locally