### PR TITLE
fix: guard back-to-top scroll handler against missing element

### DIFF
--- a/app.js
+++ b/app.js
@@ -616,6 +616,7 @@ let topBtn = document.getElementById("topBtn");
 
 // show button when scrolling
 window.onscroll = function () {
+  if (!topBtn) return;
   if (document.documentElement.scrollTop > 100) {
     topBtn.style.display = "block";
   } else {


### PR DESCRIPTION
The Back to Top feature added in a recent commit wires \`window.onscroll\` in the shared \`app.js\` file to reference \`document.getElementById("topBtn")\`, but the \`#topBtn\` element was only added to 7 of the 17 HTML pages (about, collections, contact, designers, furniture, index, trends). Since \`app.js\` is loaded on every page, scrolling on any of the remaining pages (cart, wishlist, search, faq, journal, seating, story, tables, lighting, accessories) throws an uncaught TypeError because \`topBtn\` is null there, breaking the scroll handler on those pages.

This adds a simple null check so the handler no-ops gracefully on pages without the button, instead of throwing.