### PR TITLE
fix: add homepage navigation to login and signup pages

### DIFF
--- a/login.html
+++ b/login.html
@@ -213,7 +213,7 @@
 <div class="login-container">
     <div class="login-box">
 
-        <div class="logo">FURNIX.</div>
+        <a href="index.html" class="logo" style="display:block; text-decoration:none;">FURNIX.</a>
         <p class="subtitle">Welcome Back</p>
 
         <div id="formMessage" class="form-message"></div>

--- a/signup.html
+++ b/signup.html
@@ -194,7 +194,7 @@
 <div class="login-container">
     <div class="login-box">
 
-        <div class="logo">FURNIX.</div>
+        <a href="index.html" class="logo" style="display:block; text-decoration:none;">FURNIX.</a>
         <p class="subtitle">Create Your Account</p>
 
         <div id="formMessage" class="form-message"></div>


### PR DESCRIPTION
Summary

This PR resolves the navigation lockout issue on the authentication pages by making the FURNIX logo clickable on both login.html and signup.html.

Changes Made
Wrapped the FURNIX logo/header in login.html with a link to index.html.
Wrapped the FURNIX logo/header in signup.html with a link to index.html.
Result

Users can now easily navigate back to the homepage from the login and signup pages without relying on the browser's Back button, improving the overall user experience.

Closes #166 