### PR TITLE
style: center product card text and fix padding overflow

### DIFF
--- a/Furnix-main/style.css
+++ b/Furnix-main/style.css
@@ -531,6 +531,11 @@ del {
 .product-card {
     flex: 1;
     flex-basis: 250px;
+    text-align: center;
+}
+
+.product-card > div:not(.product-image) {
+    padding: 0 1.2rem 1.2rem 1.2rem;
 }
 
 .product-image {

--- a/style.css
+++ b/style.css
@@ -607,6 +607,11 @@ del {
 .product-card {
   flex: 1;
   flex-basis: 250px;
+  text-align: center;
+}
+
+.product-card > div:not(.product-image) {
+  padding: 0 1.2rem 1.2rem 1.2rem;
 }
 
 .product-image {
@@ -2685,7 +2690,7 @@ span,
   background-color: var(--surface);
   border: 1px solid var(--border);
   border-radius: 1.5rem;
-  padding-bottom: 1rem;
+  padding-bottom: 0;
 }
 [data-theme="dark"] .product-card .product-image {
   border-bottom-left-radius: 0;


### PR DESCRIPTION
fixes : #171 

**Solution:**
- Centered text inside .product-card.
- Added inner padding to details wrapper div to keep text clear of corners.
- Streamlined dark mode bottom padding to ensure clean spacing.