### PR TITLE
fix(catalog): resolve broken image asset paths across the product display grid

### DIFF
--- a/furniture.html
+++ b/furniture.html
@@ -282,7 +282,7 @@
           >
             <div class="product-image">
               <img
-                src="images/modern chair.png"
+                src="images/modern chair.webp"
                 alt="Modern Chair"
                 width="700"
                 height="846"
@@ -315,7 +315,7 @@
           >
             <div class="product-image">
               <img
-                src="images/lounge chair.png"
+                src="images/lounge chair.webp"
                 alt="Lounge Chair"
                 width="700"
                 height="871"
@@ -348,7 +348,7 @@
           >
             <div class="product-image">
               <img
-                src="images/side table.png"
+                src="images/side table.webp"
                 alt="Side Table"
                 width="700"
                 height="808"
@@ -381,7 +381,7 @@
           >
             <div class="product-image">
               <img
-                src="images/hanging lamp.png"
+                src="images/hanging lamp.webp"
                 alt="Aura Pendent Lamp"
                 width="700"
                 height="700"
@@ -414,7 +414,7 @@
           >
             <div class="product-image">
               <img
-                src="images/flower-vase.png"
+                src="images/flower-vase.webp"
                 alt="Flower Vase"
                 width="700"
                 height="846"
@@ -447,7 +447,7 @@
           >
             <div class="product-image">
               <img
-                src="images/bed.png"
+                src="images/bed.webp"
                 alt="Modern Bed"
                 width="1000"
                 height="418"
@@ -480,7 +480,7 @@
           >
             <div class="product-image">
               <img
-                src="images/sofa.png"
+                src="images/sofa.webp"
                 alt="Luxury Sofa"
                 width="900"
                 height="394"


### PR DESCRIPTION
## Summary

This PR fixes broken product images in the furniture catalog by updating incorrect image references from `.png` to `.webp` in `furniture.html`.

## Changes Made

- Updated product image paths to match the existing `.webp` assets.
- Verified that product images render correctly in the catalog.

Related to #217