### PR TITLE
feat: add reusable toast notification system replacing all alert() calls across the application

### DIFF
--- a/Lighting.html
+++ b/Lighting.html
@@ -197,7 +197,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -245,6 +245,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -162,7 +162,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -210,6 +210,7 @@
     </footer>
 <button id="topBtn" onclick="scrollToTop()">↑ Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/accessories.html
+++ b/accessories.html
@@ -194,7 +194,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -242,6 +242,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/account.html
+++ b/account.html
@@ -85,7 +85,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -132,6 +132,7 @@
         </div>
     </footer>
 
+    <script src="toast.js"></script>
     <script type="module" src="account-auth.js"></script>
 </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -320,7 +320,7 @@ const proceedBtn = document.getElementById("proceedToCheckoutBtn");
 if (proceedBtn) {
   proceedBtn.addEventListener("click", () => {
     if (getCart().length === 0) {
-      alert("Your cart is empty!");
+      showToast("Your cart is empty!", "warning");
       return;
     }
     goToStep(2);
@@ -401,7 +401,7 @@ if (placeOrderBtn) {
     ).value;
 
     if (!firstName || !email || !address) {
-      alert("Please fill in all required shipping details.");
+      showToast("Please fill in all required shipping details.", "error");
       return;
     }
     if (payment === "card") {
@@ -410,25 +410,25 @@ if (placeOrderBtn) {
       const cvv = document.getElementById("cardCvv").value.trim();
 
       if (!cardNumber || !expiry || !cvv) {
-        alert("Please fill in your card details.");
+        showToast("Please fill in your card details.", "error");
         return;
       }
 
       const digitsOnly = cardNumber.replace(/\s/g, "");
       if (!/^\d{13,19}$/.test(digitsOnly) || !isValidLuhn(digitsOnly)) {
-        alert("Please enter a valid card number.");
+        showToast("Please enter a valid card number.", "error");
         return;
       }
 
       const expiryMatch = expiry.match(/^(\d{2})\s*\/\s*(\d{2})$/);
       if (!expiryMatch) {
-        alert("Please enter a valid expiry date (MM / YY).");
+        showToast("Please enter a valid expiry date (MM / YY).", "error");
         return;
       }
       const expMonth = parseInt(expiryMatch[1], 10);
       const expYear = 2000 + parseInt(expiryMatch[2], 10);
       if (expMonth < 1 || expMonth > 12) {
-        alert("Please enter a valid expiry month (01-12).");
+        showToast("Please enter a valid expiry month (01-12).", "error");
         return;
       }
       const now = new Date();
@@ -440,24 +440,24 @@ if (placeOrderBtn) {
         expYear < currentYear ||
         (expYear === currentYear && expMonth < currentMonth)
       ) {
-        alert("This card has expired. Please use a valid card.");
+        showToast("This card has expired. Please use a valid card.", "error");
         return;
       }
       // Reject unreasonably far-future dates (basic sanity check, e.g. typo like 99)
       if (expYear > currentYear + 20) {
-        alert("Please enter a valid expiry date.");
+        showToast("Please enter a valid expiry date.", "error");
         return;
       }
 
       if (!/^\d{3,4}$/.test(cvv)) {
-        alert("Please enter a valid CVV (3-4 digits).");
+        showToast("Please enter a valid CVV (3-4 digits).", "error");
         return;
       }
     }
     if (payment === "upi") {
       const upiId = document.getElementById("upiId").value.trim();
       if (!upiId || !upiId.includes("@")) {
-        alert("Please enter a valid UPI ID.");
+        showToast("Please enter a valid UPI ID.", "error");
         return;
       }
     }
@@ -537,7 +537,7 @@ function renderWishlistPage() {
       const item = getWishlist().find((i) => i.id === btn.dataset.id);
       if (!item) return;
       addToCart({ ...item });
-      alert(`${item.name} moved to cart!`);
+      showToast(`${item.name} moved to cart!`, "success");
       updateCartBadge(); // ✅ update cart badge
     });
   });
@@ -905,7 +905,7 @@ function shareProduct(title, urlEnding) {
     navigator.clipboard
       .writeText(fullUrl)
       .then(() => {
-        alert(`${title} link copied to clipboard!`);
+        showToast(`${title} link copied to clipboard!`, "success");
       })
       .catch((err) => console.error("Could not copy link:", err));
   }

--- a/cart.html
+++ b/cart.html
@@ -279,7 +279,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -327,6 +327,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/collections.html
+++ b/collections.html
@@ -156,7 +156,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -204,6 +204,7 @@
     </footer>
 <button id="topBtn" onclick="scrollToTop()">↑ Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -194,7 +194,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -255,6 +255,7 @@
     </footer>
     <button id="topBtn" onclick="scrollToTop()">↑ Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/designers.html
+++ b/designers.html
@@ -153,7 +153,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -201,6 +201,7 @@
     </footer>
 <button id="topBtn" onclick="scrollToTop()">↑ Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -120,7 +120,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -168,6 +168,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/furniture.html
+++ b/furniture.html
@@ -516,7 +516,7 @@
             sign up to receive 10% off <br />
             on your first order
           </h3>
-          <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+          <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input
               type="email"
               name="email"
@@ -603,6 +603,7 @@
     </footer>
     <button id="topBtn" onclick="scrollToTop()">↑ Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -457,7 +457,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="email" aria-label="Email address for newsletter" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -505,6 +505,7 @@
     </footer>
     <button id="topBtn" type="button" aria-label="Back to top">Back to Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 
 </body>

--- a/journal.html
+++ b/journal.html
@@ -137,7 +137,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -185,6 +185,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -104,7 +104,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -152,6 +152,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
     <script>
         // ---------- PRODUCT DATABASE (matches furniture.html) ----------

--- a/seating.html
+++ b/seating.html
@@ -195,7 +195,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -243,6 +243,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/story.html
+++ b/story.html
@@ -124,7 +124,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -172,6 +172,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -2720,3 +2720,92 @@ a:focus-visible {
 .favorite-icon:hover, .favorite-icon:focus {
     color: var(--golden-hour) !important;
 }
+
+/* ============================================
+   TOAST NOTIFICATION SYSTEM
+   ============================================ */
+.toast-container {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.25rem;
+  z-index: 99999;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 380px;
+  width: calc(100% - 2.5rem);
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  background: var(--card, #fff);
+  color: var(--text, #111);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.15);
+  border: 1px solid var(--border, #eaeaea);
+  pointer-events: auto;
+  transform: translateX(120%);
+  opacity: 0;
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 0.3s ease;
+}
+
+.toast-visible {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.toast-dismissing {
+  transform: translateX(120%);
+  opacity: 0;
+}
+
+.toast i {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+}
+
+.toast-success i { color: #256029; }
+.toast-error i { color: #9b281a; }
+.toast-info i { color: #2563eb; }
+.toast-warning i { color: #d97706; }
+
+.toast-message {
+  flex: 1;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  font-size: 1.3rem;
+  cursor: pointer;
+  color: var(--text-muted, #888);
+  padding: 0 0 0 0.25rem;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.toast-close:hover {
+  color: var(--text, #111);
+}
+
+[data-theme="dark"] .toast {
+  background: var(--surface, #1f1f1f);
+  border-color: var(--border, #303030);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+
+@media (max-width: 480px) {
+  .toast-container {
+    left: 1.25rem;
+    right: 1.25rem;
+    max-width: none;
+  }
+}

--- a/tables.html
+++ b/tables.html
@@ -180,7 +180,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -228,6 +228,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/toast.js
+++ b/toast.js
@@ -1,0 +1,71 @@
+(function() {
+  let container = null;
+
+  function getContainer() {
+    if (!container) {
+      container = document.createElement('div');
+      container.className = 'toast-container';
+      container.setAttribute('aria-live', 'polite');
+      container.setAttribute('aria-atomic', 'true');
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+
+  function createToast(message, type, duration) {
+    const toast = document.createElement('div');
+    toast.className = 'toast toast-' + type;
+    toast.setAttribute('role', 'alert');
+
+    const iconMap = {
+      success: 'fa-circle-check',
+      error: 'fa-circle-exclamation',
+      info: 'fa-circle-info',
+      warning: 'fa-triangle-exclamation',
+    };
+    const iconClass = iconMap[type] || 'fa-circle-info';
+
+    toast.innerHTML =
+      '<i class="fa-solid ' + iconClass + '" aria-hidden="true"></i>' +
+      '<span class="toast-message">' + message + '</span>' +
+      '<button class="toast-close" aria-label="Close notification">&times;</button>';
+
+    const closeBtn = toast.querySelector('.toast-close');
+    closeBtn.addEventListener('click', function() {
+      dismiss(toast);
+    });
+
+    getContainer().appendChild(toast);
+
+    requestAnimationFrame(function() {
+      toast.classList.add('toast-visible');
+    });
+
+    if (duration > 0) {
+      setTimeout(function() {
+        dismiss(toast);
+      }, duration);
+    }
+
+    return toast;
+  }
+
+  function dismiss(toast) {
+    if (!toast || toast.classList.contains('toast-dismissing')) return;
+    toast.classList.add('toast-dismissing');
+    toast.classList.remove('toast-visible');
+    setTimeout(function() {
+      if (toast.parentNode) {
+        toast.parentNode.removeChild(toast);
+      }
+    }, 300);
+  }
+
+  window.showToast = function(message, type, duration) {
+    type = type || 'info';
+    duration = duration || 4000;
+    return createToast(message, type, duration);
+  };
+
+  window.dismissToast = dismiss;
+})();

--- a/trends.html
+++ b/trends.html
@@ -135,7 +135,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -183,6 +183,7 @@
     </footer>
     <button id="topBtn" onclick="scrollToTop()">↑ Top</button>
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>

--- a/wishlist.html
+++ b/wishlist.html
@@ -98,7 +98,7 @@
             <div class="footer-wrapper">
                 <a href="index.html" class="logo">Furnix.</a>
                 <h3>sign up to receive 10% off <br> on your first order</h3>
-                <form class="input-container" onsubmit="event.preventDefault(); if(typeof showToast === 'function') showToast('Subscribed to newsletter!', 'success'); else alert('Subscribed to newsletter!');">
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
                     <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
                     <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
                 </form>
@@ -146,6 +146,7 @@
     </footer>
 
     <script src="app.js"></script>
+    <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #235 

**Description:**
Replaces every native `alert()` call across the application with a styled, non-blocking toast notification system. Supports success, error, info, and warning types with auto-dismiss and stacking.

**Changes:**

```
toast.js    | 71 ++++++++++++++++++++++++++
style.css   | 89 +++++++++++++++++++++++++++++++++++
app.js      | 24 ++++++-----------
19 HTML files | 19 +  insertions (script include + alert replacement)
21 files changed, 208 insertions(+), 30 deletions(-)
```

- `toast.js`: `showToast(message, type, duration)` API, auto-dismiss, stacking, dismiss button
- `style.css`: Toast container, 4 type variants, slide-in/slide-out animations, responsive positioning
- `app.js`: Replaced alert() calls with showToast() for cart add/remove, wishlist, errors
- All 19 pages: Script include for toast.js, alert() → showToast() replacement
