### PR TITLE
fix: validate all checkout shipping fields with visible error feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -390,20 +390,98 @@ function isValidLuhn(digitsOnly) {
   return sum % 10 === 0;
 }
 
+function showFieldError(fieldId, message) {
+  const field = document.getElementById(fieldId);
+  const errorEl = document.getElementById(fieldId + "Error");
+  if (!field) return;
+  field.classList.add("input-error");
+  if (errorEl) {
+    errorEl.textContent = message;
+    errorEl.style.display = "block";
+  }
+}
+
+function clearFieldErrors() {
+  document.querySelectorAll(".field-error").forEach((el) => {
+    el.textContent = "";
+    el.style.display = "none";
+  });
+  document.querySelectorAll(".input-error").forEach((el) => {
+    el.classList.remove("input-error");
+  });
+}
+
 const placeOrderBtn = document.getElementById("placeOrderBtn");
 if (placeOrderBtn) {
   placeOrderBtn.addEventListener("click", () => {
+    clearFieldErrors();
+
     const firstName = document.getElementById("firstName").value.trim();
+    const lastName = document.getElementById("lastName").value.trim();
     const email = document.getElementById("checkoutEmail").value.trim();
+    const phone = document.getElementById("phone").value.trim();
     const address = document.getElementById("address").value.trim();
+    const city = document.getElementById("city").value.trim();
+    const pincode = document.getElementById("pincode").value.trim();
     const payment = document.querySelector(
       'input[name="payment"]:checked',
     ).value;
 
-    if (!firstName || !email || !address) {
-      alert("Please fill in all required shipping details.");
-      return;
+    let hasError = false;
+
+    if (!firstName) {
+      showFieldError("firstName", "First name is required.");
+      if (!hasError) { document.getElementById("firstName").focus(); hasError = true; }
+    } else if (firstName.length < 2) {
+      showFieldError("firstName", "First name must be at least 2 characters.");
+      if (!hasError) { document.getElementById("firstName").focus(); hasError = true; }
     }
+    if (!lastName) {
+      showFieldError("lastName", "Last name is required.");
+      if (!hasError) { document.getElementById("lastName").focus(); hasError = true; }
+    } else if (lastName.length < 2) {
+      showFieldError("lastName", "Last name must be at least 2 characters.");
+      if (!hasError) { document.getElementById("lastName").focus(); hasError = true; }
+    }
+
+    if (!email) {
+      showFieldError("checkoutEmail", "Email address is required.");
+      if (!hasError) { document.getElementById("checkoutEmail").focus(); hasError = true; }
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      showFieldError("checkoutEmail", "Please enter a valid email address.");
+      if (!hasError) { document.getElementById("checkoutEmail").focus(); hasError = true; }
+    }
+
+    if (!phone) {
+      showFieldError("phone", "Phone number is required.");
+      if (!hasError) { document.getElementById("phone").focus(); hasError = true; }
+    } else if (!/^[\+\d\s\-()]{7,20}$/.test(phone)) {
+      showFieldError("phone", "Please enter a valid phone number.");
+      if (!hasError) { document.getElementById("phone").focus(); hasError = true; }
+    }
+
+    if (!address) {
+      showFieldError("address", "Street address is required.");
+      if (!hasError) { document.getElementById("address").focus(); hasError = true; }
+    }
+
+    if (!city) {
+      showFieldError("city", "City is required.");
+      if (!hasError) { document.getElementById("city").focus(); hasError = true; }
+    } else if (city.length < 2) {
+      showFieldError("city", "Please enter a valid city name.");
+      if (!hasError) { document.getElementById("city").focus(); hasError = true; }
+    }
+
+    if (!pincode) {
+      showFieldError("pincode", "Pincode is required.");
+      if (!hasError) { document.getElementById("pincode").focus(); hasError = true; }
+    } else if (!/^[0-9]{5,10}$/.test(pincode)) {
+      showFieldError("pincode", "Please enter a valid pincode (5-10 digits).");
+      if (!hasError) { document.getElementById("pincode").focus(); hasError = true; }
+    }
+
+    if (hasError) return;
     if (payment === "card") {
       const cardNumber = document.getElementById("cardNumber").value.trim();
       const expiry = document.getElementById("cardExpiry").value.trim();

--- a/cart.html
+++ b/cart.html
@@ -160,38 +160,47 @@
                             <h4 class="checkout-form-title">
                                 <i class="fa-solid fa-location-dot" aria-hidden="true"></i> Shipping Details
                             </h4>
-                            <div class="form-row">
-                                <div class="form-group">
-                                    <label for="firstName" class="form-label">First Name</label>
-                                    <input type="text" id="firstName" class="form-input" placeholder="John" required>
+                            <form id="checkoutForm" novalidate>
+                                <div class="form-row">
+                                    <div class="form-group">
+                                        <label for="firstName" class="form-label">First Name</label>
+                                        <input type="text" id="firstName" class="form-input" placeholder="John" autocomplete="given-name" pattern="[A-Za-zÀ-ÿ\-' ]{2,}" required>
+                                        <span class="field-error" id="firstNameError" role="alert"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="lastName" class="form-label">Last Name</label>
+                                        <input type="text" id="lastName" class="form-input" placeholder="Doe" autocomplete="family-name" pattern="[A-Za-zÀ-ÿ\-' ]{2,}" required>
+                                        <span class="field-error" id="lastNameError" role="alert"></span>
+                                    </div>
                                 </div>
                                 <div class="form-group">
-                                    <label for="lastName" class="form-label">Last Name</label>
-                                    <input type="text" id="lastName" class="form-input" placeholder="Doe" required>
-                                </div>
-                            </div>
-                            <div class="form-group">
-                                <label for="checkoutEmail" class="form-label">Email Address</label>
-                                <input type="email" id="checkoutEmail" class="form-input" placeholder="johndoe@email.com" required>
-                            </div>
-                            <div class="form-group">
-                                <label for="phone" class="form-label">Phone Number</label>
-                                <input type="tel" id="phone" class="form-input" placeholder="+91 98765 43210" required>
-                            </div>
-                            <div class="form-group">
-                                <label for="address" class="form-label">Street Address</label>
-                                <input type="text" id="address" class="form-input" placeholder="123 Main Street, Apt 4B" required>
-                            </div>
-                            <div class="form-row">
-                                <div class="form-group">
-                                    <label for="city" class="form-label">City</label>
-                                    <input type="text" id="city" class="form-input" placeholder="New Delhi" required>
+                                    <label for="checkoutEmail" class="form-label">Email Address</label>
+                                    <input type="email" id="checkoutEmail" class="form-input" placeholder="johndoe@email.com" autocomplete="email" required>
+                                    <span class="field-error" id="checkoutEmailError" role="alert"></span>
                                 </div>
                                 <div class="form-group">
-                                    <label for="pincode" class="form-label">Pincode</label>
-                                    <input type="text" id="pincode" class="form-input" placeholder="110001" required>
+                                    <label for="phone" class="form-label">Phone Number</label>
+                                    <input type="tel" id="phone" class="form-input" placeholder="+91 98765 43210" autocomplete="tel" pattern="[\+\d\s\-()]{7,20}" required>
+                                    <span class="field-error" id="phoneError" role="alert"></span>
                                 </div>
-                            </div>
+                                <div class="form-group">
+                                    <label for="address" class="form-label">Street Address</label>
+                                    <input type="text" id="address" class="form-input" placeholder="123 Main Street, Apt 4B" autocomplete="street-address" required>
+                                    <span class="field-error" id="addressError" role="alert"></span>
+                                </div>
+                                <div class="form-row">
+                                    <div class="form-group">
+                                        <label for="city" class="form-label">City</label>
+                                        <input type="text" id="city" class="form-input" placeholder="New Delhi" autocomplete="address-level2" pattern="[A-Za-zÀ-ÿ\-' .]{2,}" required>
+                                        <span class="field-error" id="cityError" role="alert"></span>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="pincode" class="form-label">Pincode</label>
+                                        <input type="text" id="pincode" class="form-input" placeholder="110001" autocomplete="postal-code" pattern="[0-9]{5,10}" inputmode="numeric" required>
+                                        <span class="field-error" id="pincodeError" role="alert"></span>
+                                    </div>
+                                </div>
+                            </form>
                         </div>
 
                         <div class="checkout-block">

--- a/style.css
+++ b/style.css
@@ -2720,3 +2720,21 @@ a:focus-visible {
 .favorite-icon:hover, .favorite-icon:focus {
     color: var(--golden-hour) !important;
 }
+
+.field-error {
+    display: none;
+    color: #dc3545;
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+    line-height: 1.3;
+}
+
+.input-error {
+    border-color: #dc3545 !important;
+    box-shadow: 0 0 0 1px #dc3545;
+}
+
+.input-error:focus {
+    border-color: #dc3545 !important;
+    box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
+}


### PR DESCRIPTION
# Related Issue
Closes #254 

# Summary
Enhances the checkout form to validate all seven required shipping fields with specific inline error messages and accessible feedback.

# Changes Made
- Wrapped shipping fields in `<form id="checkoutForm" novalidate>` with semantic autocomplete, pattern, and inputmode attributes
- Added showFieldError/clearFieldErrors helper functions for inline error display
- Validated firstName, lastName, email, phone, address, city, and pincode with specific messages
- Added `.field-error` and `.input-error` CSS classes with visible styling
- Removed generic `alert()` calls in favor of accessible field-level feedback
- Focus shifts to the first invalid field during validation

# Testing
- Tested each missing required shipping field produces a visible error message
- Tested invalid email, phone, and pincode values produce format-specific messages
- Tested all three payment methods (card, UPI, cash-on-delivery) still work
- Verified keyboard form submission and focus behavior
- Checked checkout layout on mobile and desktop widths

# Impact
Improves fulfillment data quality and prevents customers from receiving success confirmation for incomplete orders. Provides accessible, specific validation feedback.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered