### PR TITLE
fix(cart): correct Continue Shopping navigation route

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -141,7 +141,7 @@
                             <span id="summaryTotal">$0.00</span>
                         </div>
                         <button class="btn summary-checkout-btn" id="proceedToCheckoutBtn">Proceed to Checkout</button>
-                        <a href="furniture.html" class="footer-link continue-shopping-link">Continue Shopping</a>
+                        <a href="index.html" class="footer-link continue-shopping-link">Continue Shopping</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Description
Updated the "Continue Shopping" link in cart.html to redirect users to the main catalog page.

## Changes Made
- Changed href from furniture.html to index.html
- Fixed incorrect navigation route from cart page

## Testing
- Verified that clicking "Continue Shopping" navigates to the main storefront page successfully.