### PR TITLE
feat: create custom branded 404 error page (#275)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Page not found. Looks like this page got lost in our warehouse.">
+    <meta name="theme-color" content="#f1b555">
+    <title>Furnix - 404 Page Not Found</title>
+        <!-- Fonts added for consistency -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+
+<script src="scripts/init-theme.js"></script>
+<style>
+    .not-found-section {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        min-height: 60vh;
+        padding: 4rem 1rem;
+    }
+    .not-found-title {
+        font-size: 8rem;
+        line-height: 1;
+        margin-bottom: 1rem;
+    }
+    .not-found-message {
+        font-size: 1.25rem;
+        margin-bottom: 2.5rem;
+        max-width: 500px;
+    }
+    .not-found-actions {
+        display: flex;
+        gap: 1.5rem;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+    .btn-outline {
+        border: 1px solid var(--text-color, #111111);
+        background: transparent;
+        color: var(--text-color, #111111);
+    }
+    .btn-outline:hover {
+        background: var(--text-color, #111111);
+        color: var(--bg-color, #ffffff);
+    }
+</style>
+</head>
+<body>
+    <header>
+        <nav class="navbar flex between wrapper">
+            <a href="index.html" class="logo">Furnix.</a>
+            <ul class="navList" id="list" aria-hidden="true">
+                <li class="nav-close-item"><button class="nav-close-btn" id="navClose" aria-label="Close menu">
+                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button></li>
+                <li><a href="collections.html" class="link">collections</a></li>
+                <li><a href="furniture.html" class="link">furniture</a></li>
+                <li><a href="designers.html" class="link">designers</a></li>
+                <li><a href="trends.html" class="link">trends</a></li>
+                <li><a href="about.html" class="link">about us</a></li>
+                <li><a href="contact.html" class="link">contact us</a></li>
+                <li class="nav-social-item"><ul class="footer-social-icon flex">
+                    <li><a href="#" class="icon" aria-label="Facebook"><i class="fa-brands fa-facebook-f" aria-hidden="true"></i></a></li>
+                    <li><a href="#" class="icon" aria-label="X"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a></li>
+                    <li><a href="#" class="icon" aria-label="Instagram"><i class="fa-brands fa-instagram" aria-hidden="true"></i></a></li>
+                    <li><a href="#" class="icon" aria-label="Pinterest"><i class="fa-brands fa-pinterest-p" aria-hidden="true"></i></a></li>
+                </ul></li>
+            </ul>
+            <ul class="nav-icons flex g-one-half">
+                <li>
+                    <button class="theme-toggle" id="themeToggle" aria-label="Toggle Dark Mode">
+                        <i class="fa-solid fa-moon" id="themeIcon" aria-hidden="true"></i>
+                    </button>
+                </li>
+                <li><a href="search.html" class="icon" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></a></li>
+                <li><a href="login.html" class="icon" aria-label="Account"><i class="fa-solid fa-user" aria-hidden="true"></i></a></li>
+                <li>
+                    <a href="wishlist.html" class="icon nav-icon-wrapper" aria-label="Wishlist">
+                        <i class="fa-solid fa-heart" aria-hidden="true"></i>
+                        <span id="wishlist-badge" class="nav-badge">0</span>
+                    </a>
+                </li>
+                <li>
+                    <a href="cart.html" class="icon cart-nav-icon nav-icon-wrapper" aria-label="Cart">
+                        <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
+                        <span id="cart-badge" class="nav-badge">0</span>
+                    </a>
+                </li>
+                <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <section class="wrapper not-found-section">
+            <h1 class="h2-heading gradient-txt not-found-title">404</h1>
+            <h2 class="h2-heading gradient-txt"><span>Oops!</span></h2>
+            <p class="detail-info-platform not-found-message">
+                Looks like this page got lost in our warehouse.
+            </p>
+            <div class="not-found-actions">
+                <a href="index.html" class="btn brown-bg">Back to Homepage</a>
+                <a href="furniture.html" class="btn btn-outline">Explore Furniture</a>
+            </div>
+        </section>
+    </main>
+
+    <footer id="contact" class="footer-image">
+        <div class="wrapper p-block flex g-one-half">
+            <div class="footer-wrapper">
+                <a href="index.html" class="logo">Furnix.</a>
+                <h3>sign up to receive 10% off <br> on your first order</h3>
+                <form class="input-container" onsubmit="event.preventDefault(); showToast('Thanks for subscribing to our newsletter!', 'success');">
+                    <input type="email" name="email" id="footerEmail" placeholder="Enter your email.." autocomplete="off" required>
+                    <button type="submit" class="simple-icon" aria-label="Open details" style="background:none; border:none; cursor:pointer;"><i class="fa-solid fa-arrow-right" aria-hidden="true"></i></button>
+                </form>
+                <ul class="footer-social-icon flex">
+                    <li><a href="#" class="icon" aria-label="Facebook"><i class="fa-brands fa-facebook-f" aria-hidden="true"></i></a></li>
+                    <li><a href="#" class="icon" aria-label="X"><i class="fa-brands fa-x-twitter" aria-hidden="true"></i></a></li>
+                    <li><a href="#" class="icon" aria-label="Instagram"><i class="fa-brands fa-instagram" aria-hidden="true"></i></a></li>
+                    <li><a href="#" class="icon" aria-label="Pinterest"><i class="fa-brands fa-pinterest-p" aria-hidden="true"></i></a></li>
+                </ul>
+            </div>
+            <div class="footer-wrapper">
+                <h5>collections</h5>
+                <ul>
+                    <li><a href="collections.html" class="footer-link">Seating</a></li>
+                    <li><a href="furniture.html" class="footer-link">Sofas</a></li>
+                    <li><a href="furniture.html" class="footer-link">Lighting</a></li>
+                    <li><a href="furniture.html" class="footer-link">Accessories</a></li>
+                </ul>
+            </div>
+            
+            <div class="footer-wrapper">
+                <h5>Contact Us</h5>
+                <ul class="footer-contact-details">
+                    <li class="contact">
+                        <a href="tel:+91123456789" class="footer-link">+91 123 456 789</a>
+                    </li>
+                    <li class="contact">
+                        <a href="mailto:Furnixhome@info.com" class="footer-link">Furnixhome@info.com</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="footer-wrapper">
+                <h5>designers</h5>
+                <ul>
+                    <li><a href="designers.html" class="footer-link">John Oliver</a></li>
+                    <li><a href="designers.html" class="footer-link">Annie Lilt</a></li>
+                    <li><a href="designers.html" class="footer-link">Frank Daniel</a></li>
+                </ul>
+            </div>
+            <div class="footer-wrapper">
+                <h5>information</h5>
+                <ul>
+                    <li><a href="story.html" class="footer-link">our story</a></li>
+                    <li><a href="journal.html" class="footer-link">our journal</a></li>
+                    <li><a href="faq.html" class="footer-link">FAQ's</a></li>
+                    <li><a href="contact.html" class="footer-link">contact us</a></li>
+                </ul>
+            </div>
+        </div>
+    
+        <div class="copy-right mt-3">
+            <p>&copy; 2026 copyright furnix homes. All rights reserved.</p>
+        </div>
+    </footer>
+    <script src="app.js"></script>
+    <script src="toast.js"></script>
+    <script type="module" src="auth.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Description
Resolves #275

This PR introduces a custom-branded 404 Error Page (`404.html`) to improve user retention and maintain brand consistency when a user navigates to a broken link or a non-existent page.

## Changes Included
* **Added `404.html`:** A new dedicated error page consistent with the Furnix brand.
* **Branded Design:** Reused existing styles (`style.css`), header, and footer components to match the rest of the application seamlessly.
* **Custom Error Message:** Features an engaging message ("Oops! Looks like this page got lost in our warehouse.") as requested.
* **Call-to-Action (CTA):** Included two clear CTA buttons allowing users to easily navigate back to the Homepage or explore the Furniture shop instead of hitting a dead end.

## Expected Behavior
* If a user visits an invalid URL, they will be presented with this new 404 page rather than the browser's generic default error.
* Users can use the "Back to Homepage" or "Explore Furniture" buttons to continue browsing the site.