### PR TITLE
fix: resolve missing designer images by updating WebP file references

### DIFF
--- a/designers.html
+++ b/designers.html
@@ -107,7 +107,7 @@
                 
                 <div class="review-card designer-card">
                     <div class="profile-image designer-profile-image">
-                        <img src="images/profile1.jpg" alt="John Oliver" width="320" height="479" decoding="async" loading="lazy">
+                        <img src="images/profile1.webp" alt="John Oliver" width="320" height="479" decoding="async" loading="lazy">
                     </div>
                     <h5>John Oliver</h5>
                     <small class="designer-role">HEAD OF SEATING</small>
@@ -118,7 +118,7 @@
 
                 <div class="review-card designer-card">
                     <div class="profile-image designer-profile-image">
-                        <img src="images/profile2.jpg" alt="Annie Lilt" width="320" height="480" decoding="async" loading="lazy">
+                        <img src="images/profile2.webp" alt="Annie Lilt" width="320" height="480" decoding="async" loading="lazy">
                     </div>
                     <h5>Annie Lilt</h5>
                     <small class="designer-role">LIGHTING SPECIALIST</small>
@@ -129,7 +129,7 @@
 
                 <div class="review-card designer-card">
                     <div class="profile-image designer-profile-image">
-                        <img src="images/profile3.jpg" alt="Frank Daniel" width="320" height="480" decoding="async" loading="lazy">
+                        <img src="images/profile3.webp" alt="Frank Daniel" width="320" height="480" decoding="async" loading="lazy">
                     </div>
                     <h5>Frank Daniel</h5>
                     <small class="designer-role">WOODCRAFT MASTER</small>


### PR DESCRIPTION
## Description

This PR fixes the missing designer images issue by updating the image references to the correct WebP assets.

### Changes Made

- Updated incorrect designer image paths/extensions.
- Ensured designer images load correctly on the website.
- No functional changes were made outside of fixing the image assets.

## Related Issue

Closes #271 

## Testing

- Verified all designer images load correctly.
- Confirmed no broken image placeholders remain.
- Tested in the browser after the changes.