### PR TITLE
fix: remove duplicate copyright footer from furniture page

### DIFF
--- a/furniture.html
+++ b/furniture.html
@@ -571,9 +571,7 @@
             </div>
         </div>
     
-        <div class="copy-right mt-3">
-            <p>&copy; 2025 copyright furnix homes. powered by <span><i>janavi pandole</i></span></p>
-        </div>
+        
       </div>
       <div class="copy-right mt-3">
         <p>


### PR DESCRIPTION
## Description

This PR fixes the duplicate copyright section displayed on `furniture.html`.

### Changes Made
- Removed the redundant 2025 copyright footer.
- Kept the 2026 copyright section to match the homepage.
- Ensured consistency across pages.

### Issue Fixed
Fixes #267


### Testing
- Verified only one copyright section is displayed.
- Checked homepage remains unchanged.
- Tested on desktop browser.