### PR TITLE
Make contact information cards interactive

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -82,29 +82,38 @@
             <div class="contact-container">
                 <!-- Contact Info Panel -->
                 <div class="contact-info-section">
-                    <div class="contact-detail-item">
-                        <div class="contact-detail-icon">
-                            <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+                    <a class="contact-detail-link" href="https://www.google.com/maps/search/?api=1&query=123+Furnix,+Delhi,+India"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Open Furnix studio location in Google Maps">
+                        <div class="contact-detail-item">
+                            <div class="contact-detail-icon">
+                                <i class="fa-solid fa-location-dot" aria-hidden="true"></i>
+                            </div>
+                            <h4 class="contact-detail-title">Visit Our Studio</h4>
+                            <p class="detail-info-platform">123 Furnix<br>Delhi, India</p>
                         </div>
-                        <h4 class="contact-detail-title">Visit Our Studio</h4>
-                        <p class="detail-info-platform">123 Furnix<br>Delhi, India</p>
-                    </div>
+                    </a>
+                
 
-                    <div class="contact-detail-item">
-                        <div class="contact-detail-icon">
-                            <i class="fa-solid fa-phone" aria-hidden="true"></i>
+                    <a  class="contact-detail-link" href="tel:+91123456789" aria-label="Call Furnix support">
+                        <div class="contact-detail-item">
+                            <div class="contact-detail-icon">
+                                <i class="fa-solid fa-phone" aria-hidden="true"></i>
+                            </div>
+                            <h4 class="contact-detail-title">Call Us</h4>
+                            <p class="detail-info-platform">+91 123 456 789<br>Mon-Fri: 9am - 6pm</p>
                         </div>
-                        <h4 class="contact-detail-title">Call Us</h4>
-                        <p class="detail-info-platform">+91 123 456 789<br>Mon-Fri: 9am - 6pm</p>
-                    </div>
-
-                    <div class="contact-detail-item">
-                        <div class="contact-detail-icon">
-                            <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+                    </a>
+                    <a class="contact-detail-link" href="mailto:furnixhome@info.com" aria-label="Email Furnix support">
+                        <div class="contact-detail-item">
+                            <div class="contact-detail-icon">
+                                <i class="fa-solid fa-envelope" aria-hidden="true"></i>
+                            </div>
+                            <h4 class="contact-detail-title">Email Us</h4>
+                            <p class="detail-info-platform">furnixhome@info.com</p>
                         </div>
-                        <h4 class="contact-detail-title">Email Us</h4>
-                        <p class="detail-info-platform">Furnixhome@info.com</p>
-                    </div>
+                    </a>    
                 </div>
 
                 <!-- Contact Form Panel -->


### PR DESCRIPTION
## Description
This PR fixes the non-functional contact information section on the Contact page.

The contact cards were previously displaying location, phone number, and email details, but clicking on them did not trigger any action.

## Changes Made
- Added a Google Maps redirect link for the studio location. 
- Added a `tel:` link for the phone number to enable direct calling on supported devices.
- Added a `mailto:` link for the email address to open the default email client.
- Improved user interaction by making contact details clickable and accessible through the keyboard actions tab and enter.

## Issue Fixed
Fixes #268 

## Testing
- Verified that all contact links are clickable.
- Confirmed that:
  - Location opens the configured map URL.
  - Phone number triggers the calling action.
  - Email opens the default email client.
- Tested on Google Chrome.

## Files Changed
- `contact.html`

<img width="1911" height="977" alt="image" src="https://github.com/user-attachments/assets/a877acd8-f800-4099-a7e4-71587d7942d5" />
<img width="1917" height="957" alt="image" src="https://github.com/user-attachments/assets/645e29b0-7413-45f1-bfd8-b5f3121d8204" />
<img width="1907" height="971" alt="image" src="https://github.com/user-attachments/assets/a4562d15-1bad-4c92-8b75-80237ebb9371" />
