### PR TITLE
feat: add dark/light theme toggle with persistent user preference

### DIFF
--- a/Furnix-main/Lighting.html
+++ b/Furnix-main/Lighting.html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -55,6 +67,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/about.html
+++ b/Furnix-main/about.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -50,6 +62,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/accessories .html
+++ b/Furnix-main/accessories .html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -55,6 +67,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/app.js
+++ b/Furnix-main/app.js
@@ -627,3 +627,54 @@ window.onscroll = function () {
 function scrollToTop() {
   window.scrollTo({ top: 0, behavior: "smooth" });
 }
+
+
+// ── ThemeManager (dark/light mode) ──
+const THEME_KEY = 'furnix_theme';
+
+const ThemeManager = {
+  apply(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch (e) { /* storage blocked */ }
+    this.updateButton(theme);
+  },
+
+  toggle() {
+    const current = document.documentElement.getAttribute('data-theme') || 'light';
+    this.apply(current === 'dark' ? 'light' : 'dark');
+  },
+
+  updateButton(theme) {
+    const btn = document.getElementById('themeToggleBtn');
+    if (!btn) return;
+    const icon = btn.querySelector('i');
+    if (theme === 'dark') {
+      btn.setAttribute('aria-label', 'Switch to light mode');
+      if (icon) { icon.classList.replace('fa-moon', 'fa-sun'); }
+    } else {
+      btn.setAttribute('aria-label', 'Switch to dark mode');
+      if (icon) { icon.classList.replace('fa-sun', 'fa-moon'); }
+    }
+  },
+
+  init() {
+    const theme = document.documentElement.getAttribute('data-theme') || 'light';
+    this.updateButton(theme);
+
+    // Enable transitions after first paint (suppresses FOUC animation)
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        document.documentElement.classList.add('theme-transitions-enabled');
+      });
+    });
+
+    const btn = document.getElementById('themeToggleBtn');
+    if (btn) {
+      btn.addEventListener('click', () => ThemeManager.toggle());
+    }
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => ThemeManager.init());

--- a/Furnix-main/cart.html
+++ b/Furnix-main/cart.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -67,6 +79,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/collections.html
+++ b/Furnix-main/collections.html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -58,6 +70,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/contact.html
+++ b/Furnix-main/contact.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -51,6 +63,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/designers.html
+++ b/Furnix-main/designers.html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -73,6 +85,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/faq.html
+++ b/Furnix-main/faq.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -51,6 +63,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/furniture.html
+++ b/Furnix-main/furniture.html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -59,6 +71,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/index.html
+++ b/Furnix-main/index.html
@@ -12,6 +12,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -66,6 +78,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/journal.html
+++ b/Furnix-main/journal.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -51,6 +63,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/login.html
+++ b/Furnix-main/login.html
@@ -5,6 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login - Furnix</title>
 
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 

--- a/Furnix-main/search.html
+++ b/Furnix-main/search.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -52,6 +64,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/seating.html
+++ b/Furnix-main/seating.html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -55,6 +67,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/story.html
+++ b/Furnix-main/story.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -51,6 +63,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/style.css
+++ b/Furnix-main/style.css
@@ -195,6 +195,12 @@ header {
     transform: scale(1.2);
 }
 
+/* Theme toggle button base styles */
+.theme-toggle-btn {
+    background: none;
+    border: none;
+}
+
 /*  */
 .navList {
     position: fixed;
@@ -2075,4 +2081,283 @@ body {
   opacity: 0;
   animation: fadeSlideUp 0.8s ease forwards;
   animation-delay: 0.35s;
+}
+
+/* ── Dark Theme Variable Overrides ── */
+[data-theme="dark"] {
+  --back: #e8e0d6;
+  --white: #1c1c1c;
+  --gray: #2a2a2a;
+}
+
+/* Body & page background */
+[data-theme="dark"] body {
+  background-color: #121212;
+  color: #e8e0d6;
+}
+
+/* Header */
+[data-theme="dark"] header {
+  background: rgba(18, 18, 18, 0.95);
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 2px 20px rgba(0, 0, 0, 0.4);
+}
+
+/* Nav links on desktop */
+[data-theme="dark"] .navList .link {
+  color: #e8e0d6;
+}
+
+/* Mobile nav drawer */
+[data-theme="dark"] .navList {
+  background: #1e1008;
+}
+
+/* Logo */
+[data-theme="dark"] .logo {
+  color: #e8e0d6;
+}
+
+/* Nav icon buttons */
+[data-theme="dark"] .nav-icons .icon,
+[data-theme="dark"] .icon {
+  color: #e8e0d6;
+}
+
+/* Theme toggle button — no border, clean look */
+[data-theme="dark"] .theme-toggle-btn {
+  background: none;
+  border: none;
+}
+
+/* Hero background circle */
+[data-theme="dark"] .hero-section::before {
+  background: #2a2a2a;
+}
+
+/* Product image backgrounds */
+[data-theme="dark"] .product-image {
+  background: #2a2a2a;
+}
+
+/* Skeleton loading in dark mode */
+[data-theme="dark"] .skeleton {
+  background: linear-gradient(90deg, #2a2a2a 25%, #333 50%, #2a2a2a 75%);
+  background-size: 600px 100%;
+}
+
+/* Headings & text */
+[data-theme="dark"] h3,
+[data-theme="dark"] h5,
+[data-theme="dark"] h6,
+[data-theme="dark"] p,
+[data-theme="dark"] a:not(.btn):not(.footer-link) {
+  color: #e8e0d6;
+}
+
+[data-theme="dark"] .detail-info-platform,
+[data-theme="dark"] small {
+  color: #9e9e9e;
+}
+
+[data-theme="dark"] del {
+  color: #888;
+}
+
+/* Bed details card */
+[data-theme="dark"] .bed-details {
+  background-color: rgba(28, 28, 28, 0.92);
+}
+
+/* Review cards */
+[data-theme="dark"] .review-card {
+  background: linear-gradient(to top, #252525 70%, #1c1c1c 20%);
+}
+
+[data-theme="dark"] .review-card h5 {
+  color: #e8e0d6;
+}
+
+/* Service cards */
+[data-theme="dark"] .service-card {
+  background: #242424;
+}
+
+[data-theme="dark"] .service-card h5,
+[data-theme="dark"] .service-card p {
+  color: #e8e0d6;
+}
+
+/* Gradient bg section */
+[data-theme="dark"] .gradient-bg {
+  background: linear-gradient(to top, #1e1e1e 30%, #2a2a2a, #1c1c1c);
+}
+
+/* Designer cards */
+[data-theme="dark"] .designer-card {
+  background: #242424;
+  border-color: #383838;
+}
+
+[data-theme="dark"] .designer-card h5,
+[data-theme="dark"] .designer-card p {
+  color: #e8e0d6;
+}
+
+/* FAQ cards */
+[data-theme="dark"] .faq-card {
+  background: #242424;
+  border-color: #383838;
+}
+
+[data-theme="dark"] .faq-card h5 {
+  color: #e8e0d6;
+}
+
+/* Forms */
+[data-theme="dark"] .form-input,
+[data-theme="dark"] .form-textarea {
+  background: #2a2a2a;
+  color: #e8e0d6;
+  border-color: #444;
+}
+
+[data-theme="dark"] .form-input:focus,
+[data-theme="dark"] .form-textarea:focus {
+  background: #333;
+  border-color: var(--antique-brown);
+}
+
+[data-theme="dark"] .form-label {
+  color: #e8e0d6;
+}
+
+/* Contact sections */
+[data-theme="dark"] .contact-form-section {
+  background: #1e1e1e;
+  border-color: #333;
+}
+
+[data-theme="dark"] .contact-info-section {
+  background: #242424;
+}
+
+/* Cart & checkout */
+[data-theme="dark"] .cart-item-card {
+  background: #1e1e1e;
+  border-color: #333;
+}
+
+[data-theme="dark"] .cart-item-image {
+  background: #2a2a2a;
+}
+
+[data-theme="dark"] .cart-summary-box {
+  background: #1e1e1e;
+  border-color: #333;
+}
+
+[data-theme="dark"] .summary-title {
+  border-bottom-color: #333;
+}
+
+[data-theme="dark"] .summary-row.total {
+  border-top-color: #555;
+}
+
+[data-theme="dark"] .checkout-block {
+  background: #1e1e1e;
+  border-color: #333;
+}
+
+[data-theme="dark"] .checkout-order-box {
+  background: #1e1e1e;
+  border-color: #333;
+}
+
+[data-theme="dark"] .checkout-form-title {
+  color: #e8e0d6;
+  border-bottom-color: #333;
+}
+
+[data-theme="dark"] .checkout-order-item {
+  border-bottom-color: #333;
+}
+
+[data-theme="dark"] .checkout-order-item-img {
+  background: #2a2a2a;
+}
+
+[data-theme="dark"] .payment-option {
+  border-color: #444;
+}
+
+[data-theme="dark"] .payment-option:hover {
+  border-color: var(--antique-brown);
+}
+
+/* Quantity buttons */
+[data-theme="dark"] .qty-btn {
+  background: #333;
+  border-color: #555;
+  color: #e8e0d6;
+}
+
+/* Success modal */
+[data-theme="dark"] .success-box {
+  background: #1e1e1e;
+}
+
+/* Step indicator */
+[data-theme="dark"] .step-circle {
+  background: #2a2a2a;
+  border-color: #444;
+  color: #888;
+}
+
+[data-theme="dark"] .step-line {
+  background: #444;
+}
+
+/* Page section background */
+[data-theme="dark"] .page-section {
+  background: #121212;
+}
+
+/* Cart empty / wishlist empty state icons */
+[data-theme="dark"] .cart-empty-state i,
+[data-theme="dark"] .wishlist-empty-state i {
+  color: #444;
+}
+
+[data-theme="dark"] .cart-empty-state h3,
+[data-theme="dark"] .wishlist-empty-state h3 {
+  color: #666;
+}
+
+/* Wishlist remove button */
+[data-theme="dark"] .wishlist-remove-btn {
+  border-color: #444;
+  color: #888;
+}
+
+/* Back-to-cart button */
+[data-theme="dark"] .back-to-cart-btn {
+  color: var(--antique-brown);
+  border-color: var(--antique-brown);
+}
+
+/* Scroll-to-top button */
+[data-theme="dark"] #topBtn {
+  background-color: #333;
+  color: #e8e0d6;
+}
+
+/* Transition block — only applied after ThemeManager.init() enables it */
+html.theme-transitions-enabled,
+html.theme-transitions-enabled * {
+  transition:
+    background-color 250ms ease,
+    color 250ms ease,
+    border-color 250ms ease !important;
 }

--- a/Furnix-main/tabels.html
+++ b/Furnix-main/tabels.html
@@ -11,6 +11,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->
@@ -55,6 +67,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/trends.html
+++ b/Furnix-main/trends.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -51,6 +63,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/Furnix-main/wishlist.html
+++ b/Furnix-main/wishlist.html
@@ -9,6 +9,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -51,6 +63,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/account.html
+++ b/account.html
@@ -15,6 +15,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -57,6 +69,16 @@
                         <i class="fa-solid fa-shopping-bag" aria-hidden="true"></i>
                         <span id="cart-badge" class="nav-badge">0</span>
                     </a>
+                </li>
+                <li>
+                  <button
+                    class="icon theme-toggle-btn"
+                    id="themeToggleBtn"
+                    aria-label="Switch to dark mode"
+                    type="button"
+                  >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                  </button>
                 </li>
                 <li><a href="#" class="icon" id="menu" aria-label="Open menu" aria-controls="list" aria-expanded="false"><i class="fa-solid fa-bars" aria-hidden="true"></i></a></li>
             </ul>

--- a/cart.html
+++ b/cart.html
@@ -15,6 +15,18 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/index.html
+++ b/index.html
@@ -19,6 +19,18 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdnjs.cloudflare.com">
     <link href="https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+  (function() {
+    var stored = localStorage.getItem('furnix_theme');
+    if (stored === 'dark' || stored === 'light') {
+      document.documentElement.setAttribute('data-theme', stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+    }
+  })();
+</script>
     <link rel="stylesheet" href="style.css">
 
     <!-- icons -->


### PR DESCRIPTION

This PR implements a Dark/Light theme toggle with persistent user preference.

### Changes Made
- Added a theme toggle button in the navigation/header.
- Implemented Dark and Light themes using CSS custom properties.
- Saved theme preference using localStorage.
- Added FOUC prevention for smooth initial theme loading.
- Ensured accessibility and responsive behavior.
- Updated all required pages to support both themes.

Fixes #263
