### PR TITLE
Fix missing dark/light theme toggle on Account page (#263)

### DIFF
--- a/account.html
+++ b/account.html
@@ -20,9 +20,9 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
-</head>
-<body>
+<link rel="manifest" href="/site.webmanifest">
+    <script src="scripts/init-theme.js"></script>
+</head><body>
     <header>
         <nav class="navbar flex between wrapper">
             <a href="index.html" class="logo">Furnix.</a>
@@ -43,9 +43,13 @@
                     <li><a href="#" class="icon" aria-label="Pinterest"><i class="fa-brands fa-pinterest-p" aria-hidden="true"></i></a></li>
                 </ul></li>
             </ul>
-            <ul class="nav-icons flex g-one-half">
-                <li><a href="search.html" class="icon" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></a></li>
-                <li><a href="login.html" class="icon" aria-label="Account"><i class="fa-solid fa-user" aria-hidden="true"></i></a></li>
+<ul class="nav-icons flex g-one-half">
+                <li>
+                    <button class="theme-toggle" id="themeToggle" aria-label="Toggle Dark Mode">
+                        <i class="fa-solid fa-moon" id="themeIcon" aria-hidden="true"></i>
+                    </button>
+                </li>
+                <li><a href="search.html" class="icon" aria-label="Search"><i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i></a></li>                <li><a href="login.html" class="icon" aria-label="Account"><i class="fa-solid fa-user" aria-hidden="true"></i></a></li>
                 <li>
                     <a href="wishlist.html" class="icon nav-icon-wrapper" aria-label="Wishlist">
                         <i class="fa-solid fa-heart" aria-hidden="true"></i>
@@ -138,7 +142,7 @@
         </div>
     </footer>
 
+<script src="app.js"></script>
     <script src="toast.js"></script>
-    <script type="module" src="account-auth.js"></script>
-</body>
+    <script type="module" src="account-auth.js"></script></body>
 </html>


### PR DESCRIPTION
## Description
The site already has a working Dark/Light theme system (CSS variables, theme toggle button, `app.js` toggle logic, and `scripts/init-theme.js` for persisting the choice via localStorage) implemented across nearly every page, as requested in #263. However, `account.html` was missing all of it, so the Account page always loaded in light mode and had no way to switch themes.

## Changes
- Added `scripts/init-theme.js` to the `<head>` of `account.html` so the saved theme applies immediately on page load (no flash of the wrong theme).
- Added the `.theme-toggle` button (moon/sun icon) to the header nav-icons, matching every other page.
- Added `app.js` to the page's scripts so the toggle button's click handler and localStorage persistence actually work.

## Testing
Verified that switching themes on other pages (e.g. the homepage) and then navigating to `account.html` correctly preserves the selected theme, and that toggling the theme directly on `account.html` persists across page reloads and other pages.

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

Hi @janavipandole , could you please review this PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/85a9208b-ed39-494d-96fd-8653e67b1869" />