### PR TITLE
feat: [ECSoC_2026] add real-time dark mode OS preference sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,6 +507,7 @@
             <p>&copy; 2026 copyright furnix homes. All rights reserved.</p>
         </div>
     </footer>
+    <script src="scripts/theme-listener.js"></script>
     <script src="app.js"></script>
     <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
@@ -514,4 +515,3 @@
 </body>
 
 </html>
-

--- a/scripts/init-theme.js
+++ b/scripts/init-theme.js
@@ -5,6 +5,9 @@
             document.documentElement.setAttribute('data-theme', savedTheme);
         } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
             document.documentElement.setAttribute('data-theme', 'dark');
+        } else {
+            document.documentElement.setAttribute('data-theme', 'light');
         }
     } catch (e) {}
 })();
+

--- a/scripts/theme-listener.js
+++ b/scripts/theme-listener.js
@@ -1,0 +1,22 @@
+// System preference listener and theme initialization manager
+document.addEventListener("DOMContentLoaded", () => {
+    if (window.matchMedia) {
+        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+            const hasUserChoice = localStorage.getItem("theme");
+            if (!hasUserChoice) {
+                const newTheme = e.matches ? "dark" : "light";
+                document.documentElement.setAttribute("data-theme", newTheme);
+                const themeIcon = document.getElementById("themeIcon");
+                if (themeIcon) {
+                    if (newTheme === "dark") {
+                        themeIcon.classList.remove("fa-moon");
+                        themeIcon.classList.add("fa-sun");
+                    } else {
+                        themeIcon.classList.remove("fa-sun");
+                        themeIcon.classList.add("fa-moon");
+                    }
+                }
+            }
+        });
+    }
+});


### PR DESCRIPTION
# Related Issue
Closes #325

# Summary
Adds real-time OS dark mode color scheme change detection while maintaining explicit user preference persistence.

# Changes Made
- Created `scripts/theme-listener.js` with media query event listener.
- Updated `scripts/init-theme.js` for default attribute initialization.
- Linked `scripts/theme-listener.js` in `index.html`.

# Testing
- Tested OS dark mode toggle in browser developer tools (Rendering tab -> Emulate CSS media feature prefers-color-scheme).
- Confirmed icon and root `data-theme` attribute change dynamically.

# Screenshots
N/A

# Impact
Provides a modern, native-feeling user experience across operating systems.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
