### PR TITLE
docs: add environment variables section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,35 @@ cd Furnix-Neon
 open index.html
 ```
 
+---
+
+## 🔐 Environment Variables
+
+This project uses environment variables to configure the backend server for local development.
+
+### Create a `.env` File
+
+Create a `.env` file in the project root directory (the same location as `server.js`).
+
+### Example
+
+```env
+PORT=5000
+```
+
+### Environment Variables
+
+| Variable | Description | Default Value |
+|----------|-------------|---------------|
+| `PORT` | Specifies the port on which the Express server runs. If this variable is not set, the server automatically uses port `5000`. | `5000` |
+
+### Security Notes
+
+- Never commit your `.env` file or any sensitive credentials to the repository.
+- Keep environment-specific configuration values private.
+- The project's `.gitignore` already excludes `.env` and `.env.local` files from version control.
+- If additional environment variables are introduced in the future, update this section accordingly.
+
 ## 📁 Project Structure
 
 ```text


### PR DESCRIPTION
## Summary

This pull request adds a dedicated **Environment Variables** section to the `README.md` to improve the project's documentation and help contributors set up the project for local development more easily.

### Changes Made

* Added a new **Environment Variables** section to the README.
* Explained where to create the `.env` file.
* Documented the `PORT` environment variable currently used by the Express server.
* Included an example `.env` configuration with placeholder values.
* Added a brief explanation of the purpose of the environment variable.
* Included security notes reminding contributors not to commit `.env` files or sensitive configuration values.
* Mentioned that `.env` and `.env.local` are already excluded through `.gitignore`.

### Why This Change?

The previous README described the project overview, features, installation steps, and project structure, but it did not explain how environment variables should be configured during local development. This update provides clear guidance for contributors, making the setup process simpler while encouraging secure handling of configuration files.

### Benefits

* Improves the overall project documentation.
* Makes local development setup easier for new contributors.
* Follows security best practices by discouraging committing sensitive configuration files.
* Provides a clear reference for the project's current environment configuration.

Closes #351
