### PR TITLE
Add Open Graph meta tags to 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Page not found. Looks like this page got lost in our warehouse.">
+    <meta property="og:title" content="Furnix - 404 Page Not Found">
+    <meta property="og:description" content="Page not found. Looks like this page got lost in our warehouse.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="theme-color" content="#f1b555">
     <title>Furnix - 404 Page Not Found</title>
         <!-- Fonts added for consistency -->


### PR DESCRIPTION
### Description
This pull request addresses missing Open Graph tags inside the `<head>` section of the 404 error page (`404.html`).

#### Details:
* **Current Behavior:** The `og:title` and `og:description` Open Graph meta tags were omitted from the head section, causing improper link previews when sharing the error page on social media or messaging platforms.
* **Proposed Resolution:** Added standard Open Graph meta tags (`og:title`, `og:description`, `og:type`, and `og:url`) to ensure consistent branding and rich link previews across platforms.

Closes #620