### PR TITLE
Add description to og:description meta tag

### DIFF
--- a/Lighting.html
+++ b/Lighting.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Illuminate your home with Furnix's premium lighting collection featuring modern chandeliers, pendant lights, floor lamps, and architectural lighting fixtures.">
     <meta property="og:title" content="Premium Lighting - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Illuminate your home with Furnix's premium lighting collection featuring modern chandeliers, pendant lights, floor lamps, and architectural lighting fixtures.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Updated the og:description meta tag to include a description of Furnix's premium lighting collection.

### Description
This pull request populates the missing `og:description` meta tag inside the `<head>` section of `Lighting.html`.

#### Details:
* **Current Behavior:** The Open Graph description meta tag was left blank (`<meta property="og:description" content="">`), causing incomplete link previews when sharing the lighting page on social media platforms and messaging apps.
* **Proposed Resolution:** Populated the `og:description` attribute with the identical summary text as the standard page meta description.

Closes #619