### PR TITLE
Update og:description meta tag in about.html

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Learn about Furnix's journey in modern furniture design. Discover our mission to make contemporary home furnishings accessible with premium quality and stylish designs.">
     <meta property="og:title" content="About Furnix - Our Story & Mission">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Learn about Furnix's journey in modern furniture design. Discover our mission to make contemporary home furnishings accessible with premium quality and stylish designs.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
### Description
This pull request populates the missing `og:description` meta tag inside the `<head>` section of `about.html` ([Issue #618](https://github.com/janavipandole/Furnix/issues/618)).

#### Details:
* **Current Behavior:** The Open Graph description meta tag was left blank (`<meta property="og:description" content="">`), resulting in incomplete link previews when sharing the about page on social media platforms and messaging apps.
* **Proposed Resolution:** Populated the `og:description` attribute with the identical summary text from the standard page meta description.

Closes #618