### PR TITLE
fix(cart): populate missing open graph description meta tag in cart.html (#615)

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Review your Furnix furniture selections in your shopping cart. Secure checkout with fast shipping on all modern home furnishings.">
     <meta property="og:title" content="Shopping Cart - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Review your Furnix furniture selections in your shopping cart. Secure checkout with fast shipping on all modern home furnishings.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION


### Description
This pull request populates the missing `og:description` meta tag inside the `<head>` section of `cart.html` ([Issue #615](https://github.com/janavipandole/Furnix/issues/615)).

#### Details:
* **Current Behavior:** The Open Graph description meta tag was left blank (`<meta property="og:description" content="">`), resulting in incomplete link previews when sharing the cart checkout page on social media platforms and messaging apps.
* **Proposed Resolution:** Populated the `og:description` attribute with the identical summary text from the standard page meta description (regarding reviewing furniture selections and secure checkout).

Closes #615