### PR TITLE
fix(collections): populate missing open graph description meta tag in…

### DIFF
--- a/collections.html
+++ b/collections.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Browse Furnix's curated design collections featuring modern seating, architectural lighting, solid wood dining tables, and premium home decor.">
     <meta property="og:title" content="Curated Collections - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Browse Furnix's curated design collections featuring modern seating, architectural lighting, solid wood dining tables, and premium home decor.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
… collections.html (#614)

Updated the Open Graph description meta tag to provide a summary of Furnix's design collections. ### Description
This pull request populates the missing `og:description` meta tag inside the `<head>` section of `collections.html` ([Issue #614](https://github.com/janavipandole/Furnix/issues/614)).

#### Details:
* **Current Behavior:** The Open Graph description meta tag was left blank (`<meta property="og:description" content="">`), resulting in incomplete link previews when sharing the curated design collections page on social media platforms and messaging apps.
* **Proposed Resolution:** Populated the `og:description` attribute with the identical summary text from the standard page meta description.

Closes #614