### PR TITLE
Initialize fieldErrors for form validation

### DIFF
--- a/contact-form.js
+++ b/contact-form.js
@@ -9,6 +9,14 @@
   const subjectInput = document.getElementById('subject');
   const messageInput = document.getElementById('message');
 
+  // Define and initialize fieldErrors mapping object
+  const fieldErrors = {
+    'name': document.getElementById('nameError'),
+    'email': document.getElementById('emailError'),
+    'subject': document.getElementById('subjectError'),
+    'message': document.getElementById('messageError')
+  };
+
   const sanitizer = window.SecuritySanitizer || null;
   const validator = window.FurnixFormValidatorEngine || null;
 


### PR DESCRIPTION
Added fieldErrors mapping for error display elements.

### Description
This pull request addresses a potential `ReferenceError` when attempting to clear form field error indicators inside the contact form submission script (`contact-form.js`) ([Issue #613](https://github.com/janavipandole/Furnix/issues/613)).

#### Details:
* **Current Behavior:** Upon successful form submission, the code iterated through input fields and attempted to access `fieldErrors[input.id]` to reset individual error elements. However, `fieldErrors` was never declared or initialized in this scope, breaking the form reset handling and throwing an error.
* **Proposed Resolution:** Properly defined and initialized the `fieldErrors` mapping object at the top of the script so error message containers can be successfully targeted and cleared upon reset.

Closes #613