### PR TITLE
perf(script): add recursive directory traversal and case-insensitive extension matching (#610)

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -4,15 +4,29 @@ const path = require('path');
 
 const imagesDir = './images';
 
-fs.readdirSync(imagesDir).forEach(file => {
-  if (file.endsWith('.png') || file.endsWith('.jpg')) {
-    const input = path.join(imagesDir, file);
-    const output = path.join(imagesDir, file.replace(/\.(png|jpg)$/, '.webp'));
-    sharp(input)
-      .webp({ quality: 80 })
-      .toFile(output, (err) => {
-        if (err) console.error('Error converting', file, err);
-        else console.log('Converted:', file, '→', file.replace(/\.(png|jpg)$/, '.webp'));
-      });
-  }
-});
+function processDirectory(dir) {
+  // Read directory contents with file types to distinguish files from folders
+  fs.readdirSync(dir, { withFileTypes: true }).forEach(dirent => {
+    const fullPath = path.join(dir, dirent.name);
+
+    if (dirent.isDirectory()) {
+      // Recursively process nested subdirectories
+      processDirectory(fullPath);
+    } else {
+      // Use case-insensitive regex to match .png, .jpg, .PNG, .JPG, etc.
+      if (/\.(png|jpg)$/i.test(dirent.name)) {
+        const output = fullPath.replace(/\.(png|jpg)$/i, '.webp');
+        
+        sharp(fullPath)
+          .webp({ quality: 80 })
+          .toFile(output, (err) => {
+            if (err) console.error('Error converting', fullPath, err);
+            else console.log('Converted:', fullPath, '→', output);
+          });
+      }
+    }
+  });
+}
+
+// Start processing from the root images directory
+processDirectory(imagesDir);


### PR DESCRIPTION


### Description
This pull request addresses limitations in the image conversion script (`convert.js`) by enabling recursive directory traversal and adding support for uppercase file extensions ([Issue #610](https://github.com/issues/created?issue=janavipandole%7CFurnix%7C610)).

#### Details:
* **Current Behavior:** The script only read the root `./images` directory synchronously and strictly checked for lowercase `.png` or `.jpg` extensions, skipping nested subdirectories and uppercase extensions completely.
* **Proposed Resolution:** 
  1. Implemented a `processDirectory` recursive function utilizing `fs.readdirSync` with `{ withFileTypes: true }` to properly traverse and process all nested subdirectories.
  2. Updated the file extension checking and replacement logic to use a case-insensitive regular expression (`/\.(png|jpg)$/i`) to ensure extensions like `.PNG` and `.JPG` are correctly targeted and converted.

Closes #610