### PR TITLE
Add Open Graph description meta tag

### DIFF
--- a/designers.html
+++ b/designers.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Meet the talented designers behind Furnix's modern furniture collection. Learn about the creative vision shaping contemporary home interiors.">
     <meta property="og:title" content="Our Designers - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Meet the talented designers behind Furnix's modern furniture collection. Learn about the creative vision shaping contemporary home interiors.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
### Description
This pull request populates the missing `og:description` meta tag inside the `<head>` section of `designers.html` ([Issue #608](https://github.com/janavipandole/Furnix/issues/608)).

#### Details:
* **Current Behavior:** The Open Graph description meta tag was left blank (`<meta property="og:description" content="">`), resulting in incomplete link previews when sharing the designers page on social media platforms and messaging apps.
* **Proposed Resolution:** Populated the `og:description` attribute with the identical summary text from the standard page meta description.

Closes #608