### PR TITLE
fix(cart): resolve hardcoded product references and incorrect DOM layout order for Add to Cart buttons (#216)

### DIFF
--- a/furniture.html
+++ b/furniture.html
@@ -293,12 +293,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Seating</small>
               <h6>Modern Chair</h6>
-              <p class="price">$100.00</p>
+              <p class="price" style="margin-bottom: 15px;">$100.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
 
@@ -326,12 +326,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Seating</small>
               <h6>Embrace Lounge Chair</h6>
-              <p class="price">$200.00</p>
+              <p class="price" style="margin-bottom: 15px;">$200.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
 
@@ -359,12 +359,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Tables</small>
               <h6>Side Table</h6>
-              <p class="price">$150.00</p>
+              <p class="price" style="margin-bottom: 15px;">$150.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
 
@@ -392,12 +392,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Lighting</small>
               <h6>Aura Pendant Lamp</h6>
-              <p class="price">$30.00</p>
+              <p class="price" style="margin-bottom: 15px;">$30.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
 
@@ -425,12 +425,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Accessories</small>
               <h6>Flower Vase Decor</h6>
-              <p class="price">$20.00</p>
+              <p class="price" style="margin-bottom: 15px;">$20.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
 
@@ -458,12 +458,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Bedroom</small>
               <h6>Modern Scandinavian Bed</h6>
-              <p class="price">$1500.00</p>
+              <p class="price" style="margin-bottom: 15px;">$1500.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
 
@@ -491,12 +491,12 @@
               >
                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
               </a>
-              <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
             </div>
             <div>
               <small>Seating</small>
               <h6>Luxury Sectional Sofa</h6>
-              <p class="price">$1200.00</p>
+              <p class="price" style="margin-bottom: 15px;">$1200.00</p>
+              <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -255,12 +255,12 @@
                             <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
                             </a>
-                            <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
                         </div>
                         <div>
                             <small>Lighting</small>
                             <h4>Aura Pendant Lamp</h4>
-                            <p class="price">$30.00</p>
+                            <p class="price" style="margin-bottom: 15px;">$30.00</p>
+                            <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                         </div>
                     </div>
 
@@ -270,12 +270,12 @@
                             <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
                             </a>
-                            <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
                         </div>
                         <div>
                             <small>Accessories</small>
                             <h4>flower vase decor</h4>
-                            <p class="price">$20.00</p>
+                            <p class="price" style="margin-bottom: 15px;">$20.00</p>
+                            <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                         </div>
                     </div>
 
@@ -285,16 +285,15 @@
                             <a href="#" class="share-icon" aria-label="Share product" onclick="shareProduct('Modern Chair', 'seating.html')">
                                 <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
                             </a>
-
                             <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
                             </a>
-                            <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
                         </div>
                         <div>
                             <small>seating</small>
                             <h4>modern chair</h4>
-                            <p class="price">$100.00</p>
+                            <p class="price" style="margin-bottom: 15px;">$100.00</p>
+                            <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                         </div>
                     </div>
 
@@ -304,16 +303,15 @@
                             <a href="#" class="share-icon" aria-label="Share product" onclick="shareProduct('Embrace Lounge Chair', 'seating.html')">
                                 <i class="fa-solid fa-share-nodes" aria-hidden="true"></i>
                             </a>
-
                             <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
                             </a>
-                            <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
                         </div>
                         <div>
                             <small>Lighting</small>
                             <h4>embrace lounge chair</h4>
-                            <p class="price">$200.00</p>
+                            <p class="price" style="margin-bottom: 15px;">$200.00</p>
+                            <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                         </div>
                     </div>
 
@@ -323,12 +321,12 @@
                             <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                                 <i class="fa-regular fa-heart" aria-hidden="true"></i>
                             </a>
-                            <a href="#" class="btn brown-bg" data-cart-btn>Add to cart</a>
                         </div>
                         <div>
                             <small>tables</small>
                             <h4>side table</h4>
-                            <p class="price">$150.00</p>
+                            <p class="price" style="margin-bottom: 15px;">$150.00</p>
+                            <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                         </div>
                     </div>
                 </div>

--- a/seating.html
+++ b/seating.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Discover Furnix's premium seating collection featuring modern sofas, accent chairs, sectionals, and lounge furniture designed for comfort and style.">
     <meta property="og:title" content="Premium Seating - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Discover Furnix's premium seating collection featuring modern sofas, accent chairs, sectionals, and lounge furniture designed for comfort and style.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">
@@ -91,15 +91,15 @@
                 <div class="product-card">
                     <div class="product-image">
                         <img src="images/modern chair.png" alt="Modern Chair" width="700" height="846" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Seating</small>
                         <h6>Modern Chair</h6>
-                        <p class="price">$100.00</p>
+                        <p class="price" style="margin-bottom: 15px;">$100.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 
@@ -107,76 +107,76 @@
                 <div class="product-card">
                     <div class="product-image">
                         <img src="images/lounge chair.png" alt="Lounge Chair" width="700" height="871" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Seating</small>
                         <h6>Embrace Lounge Chair</h6>
-                        <p class="price">$200.00</p>
+                        <p class="price" style="margin-bottom: 15px;">$200.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 
                 <div class="product-card">
-                <div class="product-image">
-                    <img src="images/recliner.png" alt="Recliner Chair" loading="lazy" decoding="async">
-                    <a href="#" class="favorite-icon" aria-label="Add to Favorites">
-                        <i class="fa-regular fa-heart"></i>
-                    </a>
-                    <a href="#" class="btn brown-bg">Add to cart</a>
+                    <div class="product-image">
+                        <img src="images/recliner.png" alt="Recliner Chair" loading="lazy" decoding="async">
+                        <a href="#" class="favorite-icon" aria-label="Add to Favorites" data-wishlist-btn>
+                            <i class="fa-regular fa-heart"></i>
+                        </a>
+                    </div>
+                    <div>
+                        <small>Seating</small>
+                        <h6>Premium Recliner</h6>
+                        <p class="price" style="margin-bottom: 15px;">$850.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
+                    </div>
                 </div>
-                <div>
-                    <small>Seating</small>
-                    <h6>Premium Recliner</h6>
-                    <p class="price">$850.00</p>
+
+                <div class="product-card">
+                    <div class="product-image">
+                        <img src="images/AC.png" alt="Armchair" loading="lazy" decoding="async">
+                        <a href="#" class="favorite-icon" aria-label="Add to Favorites" data-wishlist-btn>
+                            <i class="fa-regular fa-heart"></i>
+                        </a>
+                    </div>
+                    <div>
+                        <small>Seating</small>
+                        <h6>Accent Armchair</h6>
+                        <p class="price" style="margin-bottom: 15px;">$450.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
+                    </div>
                 </div>
-            </div>
 
-              <div class="product-card">
-                  <div class="product-image">
-                      <img src="images/AC.png" alt="Armchair" loading="lazy" decoding="async">
-                      <a href="#" class="favorite-icon" aria-label="Add to Favorites">
-                          <i class="fa-regular fa-heart"></i>
-                      </a>
-                      <a href="#" class="btn brown-bg">Add to cart</a>
-                  </div>
-                  <div>
-                      <small>Seating</small>
-                      <h6>Accent Armchair</h6>
-                      <p class="price">$450.00</p>
-                  </div>
-              </div>
-
-                  <div class="product-card">
-                      <div class="product-image">
-                          <img src="images/sofa-chair2.png" alt="Sofa Chair" loading="lazy" decoding="async">
-                          <a href="#" class="favorite-icon" aria-label="Add to Favorites">
-                              <i class="fa-regular fa-heart"></i>
-                          </a>
-                          <a href="#" class="btn brown-bg">Add to cart</a>
-                      </div>
-                      <div>
-                          <small>Seating</small>
-                          <h6>Modern Sofa Chair</h6>
-                          <p class="price">$600.00</p>
-                      </div>
-                  </div>
+                <div class="product-card">
+                    <div class="product-image">
+                        <img src="images/sofa-chair2.png" alt="Sofa Chair" loading="lazy" decoding="async">
+                        <a href="#" class="favorite-icon" aria-label="Add to Favorites" data-wishlist-btn>
+                            <i class="fa-regular fa-heart"></i>
+                        </a>
+                    </div>
+                    <div>
+                        <small>Seating</small>
+                        <h6>Modern Sofa Chair</h6>
+                        <p class="price" style="margin-bottom: 15px;">$600.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
+                    </div>
+                </div>
                   
                 <!-- Product 7 -->
                 <div class="product-card">
                     <div class="product-image">
                         <img src="images/sofa.png" alt="Luxury Sofa" width="900" height="394" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Seating</small>
                         <h6>Luxury Sectional Sofa</h6>
-                        <p class="price">$1200.00</p>
+                        <p class="price" style="margin-bottom: 15px;">$1200.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 


### PR DESCRIPTION


### Description
This pull request addresses critical e-commerce functional and accessibility bugs on the product grid as outlined in [Issue #216](https://github.com/janavipandole/Furnix/issues/216).

#### Details:
* **Current Behavior:** 
  1. The "Add to Cart" button was structurally placed inside the `.product-image` container, meaning screen readers encountered the button before the product's category, title, and price. 
  2. The action target lacked a specific product identifier, relying on static or generic references (`href="#"`).
* **Proposed Resolution:** 
  1. **Restructured DOM Layout:** Moved the "Add to Cart" button out of the `.product-image` div and placed it at the bottom of the product details `div` (directly below the price) across all product cards. Added a small top margin for visual separation. This ensures logical DOM flow for accessibility (Category -> Title -> Price -> Button).
  2. **Dynamic Binding:** Ensured the button utilizes the `data-cart-btn` attribute so the JavaScript engine dynamically hooks into the contextual product data rather than relying on a hardcoded ID.

Closes #216