### PR TITLE
fix(faq): populate missing open graph description in faq.html (#607)

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Find answers to frequently asked questions about Furnix furniture, shipping policies, returns, warranties, and care instructions for your modern home pieces.">
     <meta property="og:title" content="FAQ - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Find answers to frequently asked questions about Furnix furniture, shipping policies, returns, warranties, and care instructions for your modern home pieces.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
### Description
This pull request populates the missing `og:description` meta tag inside the `<head>` section of `faq.html` ([Issue #607](https://github.com/janavipandole/Furnix/issues/607)).

#### Details:
* **Current Behavior:** The Open Graph description meta tag was left blank (`<meta property="og:description" content="">`), resulting in incomplete link previews when sharing the FAQ page on social media platforms and messaging apps.
* **Proposed Resolution:** Populated the `og:description` attribute with the identical summary text from the standard page meta description.

Closes #607