### PR TITLE
fix(tables): correct inaccurate alt text and product titles across product cards in tables.html (#592)

### DIFF
--- a/tables.html
+++ b/tables.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Shop Furnix's premium table collection including dining tables, coffee tables, side tables, and desks crafted from solid wood and modern materials.">
     <meta property="og:title" content="Premium Tables - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Shop Furnix's premium table collection including dining tables, coffee tables, side tables, and desks crafted from solid wood and modern materials.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">
@@ -87,83 +87,85 @@
             <!-- Products Grid -->
             <div class="products-grid">
 
-               <!-- Product 3 -->
+               <!-- Product 1 -->
                 <div class="product-card">
                     <div class="product-image">
                         <img src="images/side table.png" alt="Side Table" width="700" height="808" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Tables</small>
                         <h6>Side Table</h6>
-                        <p class="price">$150.00</p>
+                        <p class="price" style="margin-bottom: 15px;">$150.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 
+                 <!-- Product 2 -->
                  <div class="product-card">
                     <div class="product-image">
-                        <img src="images/wodden-table.png" alt="Side Table" width="700" height="808" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <img src="images/wodden-table.png" alt="Wooden Center Table" width="700" height="808" decoding="async" loading="lazy">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Tables</small>
-                        <h6>Side Table</h6>
-                        <p class="price">$250.00</p>
+                        <h6>Wooden Center Table</h6>
+                        <p class="price" style="margin-bottom: 15px;">$250.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 
+                 <!-- Product 3 -->
                  <div class="product-card">
                     <div class="product-image">
-                        <img src="images/u table.png" alt="Side Table" width="700" height="808" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <img src="images/u table.png" alt="U-Shaped Coffee Table" width="700" height="808" decoding="async" loading="lazy">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Tables</small>
-                        <h6>Side Table</h6>
-                        <p class="price">$160.00</p>
+                        <h6>U-Shaped Coffee Table</h6>
+                        <p class="price" style="margin-bottom: 15px;">$160.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 
+                 <!-- Product 4 -->
                  <div class="product-card">
                     <div class="product-image">
-                        <img src="images/orange table.png" alt="Side Table" width="700" height="808" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <img src="images/orange table.png" alt="Orange Accent Table" width="700" height="808" decoding="async" loading="lazy">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Tables</small>
-                        <h6>Side Table</h6>
-                        <p class="price">$80.00</p>
+                        <h6>Orange Accent Table</h6>
+                        <p class="price" style="margin-bottom: 15px;">$80.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
 
+                 <!-- Product 5 -->
                  <div class="product-card">
                     <div class="product-image">
-                        <img src="images/green table.png" alt="Side Table" width="700" height="808" decoding="async" loading="lazy">
-                        <a href="#" class="favorite-icon" aria-label="Add to wishlist">
+                        <img src="images/green table.png" alt="Green Modern Table" width="700" height="808" decoding="async" loading="lazy">
+                        <a href="#" class="favorite-icon" aria-label="Add to wishlist" data-wishlist-btn>
                             <i class="fa-regular fa-heart" aria-hidden="true"></i>
                         </a>
-                        <a href="#" class="btn brown-bg">Add to cart</a>
                     </div>
                     <div>
                         <small>Tables</small>
-                        <h6>Side Table</h6>
-                        <p class="price">$310.00</p>
+                        <h6>Green Modern Table</h6>
+                        <p class="price" style="margin-bottom: 15px;">$310.00</p>
+                        <a href="#" class="btn brown-bg" style="display: block; text-align: center;" data-cart-btn>Add to cart</a>
                     </div>
                 </div>
-                
-            
 
             </div>        
         </section>


### PR DESCRIPTION

### Description
This pull request addresses [Issue #592](https://github.com/janavipandole/Furnix/issues/592) by fixing the incorrect and repetitive image alternative (`alt`) descriptions and `<h6>` titles across the products in `tables.html`. It also includes the overarching layout fixes for the "Add to Cart" buttons to maintain accessibility and functionality consistency.

#### Details:
* **Alt Text & Title Corrections:** Replaced the generic `alt="Side Table"` and `<h6>Side Table</h6>` on every product card with descriptive names that match their respective image assets (e.g., "Wooden Center Table", "U-Shaped Coffee Table", "Orange Accent Table", "Green Modern Table").
* **Accessibility Layout & Data Binding:** Moved the "Add to Cart" buttons below the price tags for proper DOM flow. Added the required `data-cart-btn` and `data-wishlist-btn` attributes for the JavaScript logic to hook into properly.
* **Metadata Cleanup:** Populated the empty `og:description` meta tag for better social media link previews.

Closes #592