### PR TITLE
Update Content-Security-Policy in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
             "headers": [
                 {
                     "key": "Content-Security-Policy",
-                    "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https://lh3.googleusercontent.com; script-src 'self' https://www.gstatic.com https://apis.google.com; connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://apis.google.com; frame-src 'self' https://*.firebaseapp.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; upgrade-insecure-requests"
+                    "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https://lh3.googleusercontent.com; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://apis.google.com https://cdnjs.cloudflare.com; connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://apis.google.com; frame-src 'self' https://*.firebaseapp.com https://accounts.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; upgrade-insecure-requests"
                 },
                 {
                     "key": "Cross-Origin-Opener-Policy",


### PR DESCRIPTION
### Description
This pull request updates the `Content-Security-Policy` headers within `vercel.json` to address [Issue #594](https://github.com/janavipandole/Furnix/issues/594). 

#### Details:
* **Current Behavior:** The `script-src` directive strictly limited script execution to `'self'`, `https://www.gstatic.com`, and `https://apis.google.com`. This overly restrictive policy blocked external CDN resources (like FontAwesome loaded via Cloudflare) and essential inline initialization scripts utilized across the application.
* **Proposed Resolution:** Expanded the `script-src` directive to explicitly include `https://cdnjs.cloudflare.com` and `'unsafe-inline'`. This ensures that required external third-party UI dependencies and critical inline logic load securely and correctly without being suppressed by the browser's CSP enforcer.

Closes #594