### PR TITLE
fix(index): populate missing open graph description meta tag in index.html (#604)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Furnix offers sleek and modern furniture and interior solutions. Explore our premium collection of contemporary furniture, lighting, and decor for a stylish home.">
     <meta property="og:title" content="Furnix - Modern Furniture & Interior Solutions">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Furnix offers sleek and modern furniture and interior solutions. Explore our premium collection of contemporary furniture, lighting, and decor for a stylish home.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION


### Description
This pull request addresses an empty Open Graph description meta tag within the head section of `index.html` as reported in [Issue #604](https://github.com/janavipandole/Furnix/issues/604).

#### Details:
* **Current Behavior:** The `og:description` meta tag was previously left blank (`<meta property="og:description" content="">`), which could lead to poor or incomplete link previews on social media platforms and messaging apps. 
* **Proposed Resolution:** Populated the `og:description` content attribute with the exact same summary string used in the standard page description ("Furnix offers sleek and modern furniture and interior solutions. Explore our premium collection of contemporary furniture, lighting, and decor for a stylish home.").

Closes #604