### PR TITLE
Add Open Graph description meta tag

### DIFF
--- a/journal.html
+++ b/journal.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Read the Furnix journal for interior design inspiration, home styling tips, furniture care guides, and the latest trends in modern home decor.">
     <meta property="og:title" content="Journal - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Read the Furnix journal for interior design inspiration, home styling tips, furniture care guides, and the latest trends in modern home decor.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
### Description
This pull request addresses an empty Open Graph description meta tag within the head section of `journal.html` as reported in [Issue #603](https://github.com/janavipandole/Furnix/issues/603).

#### Details:
* **Current Behavior:** The `og:description` meta tag was left completely blank (`<meta property="og:description" content="">`), which could lead to poor or incomplete link previews on social media platforms and messaging apps. 
* **Proposed Resolution:** Populated the `og:description` content attribute with the exact same summary string used in the standard page description ("Read the Furnix journal for interior design inspiration, home styling tips, furniture care guides, and the latest trends in modern home decor.").

Closes #603