### PR TITLE
Add Open Graph description meta tag to search.html

### DIFF
--- a/search.html
+++ b/search.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Search the Furnix product catalog to find contemporary furniture, beds, accent lamps, and decorative vases for your home.">
     <meta property="og:title" content="Search - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Search the Furnix product catalog to find contemporary furniture, beds, accent lamps, and decorative vases for your home.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
### Description
This pull request addresses an empty Open Graph description meta tag within the head section of `search.html` as reported in [Issue #601](https://github.com/janavipandole/Furnix/issues/601).

#### Details:
* **Current Behavior:** The `og:description` meta tag was left completely blank (`<meta property="og:description" content="">`), which could result in poor or missing link previews when shared on social media or messaging platforms.
* **Proposed Resolution:** Populated the `og:description` content attribute with the exact same summary string used in the standard page description ("Search the Furnix product catalog to find contemporary furniture, beds, accent lamps, and decorative vases for your home.").

Closes #601