### PR TITLE
Add Open Graph description meta tag

### DIFF
--- a/trends.html
+++ b/trends.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Stay ahead with Furnix's interior design trends. Explore the latest in modern furniture styles, color palettes, and home decor inspirations.">
     <meta property="og:title" content="Interior Trends - Furnix">
-    <meta property="og:description" content="">
+    <meta property="og:description" content="Stay ahead with Furnix's interior design trends. Explore the latest in modern furniture styles, color palettes, and home decor inspirations.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://furnix-neon.vercel.app/">
     <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
### Description
This pull request addresses an empty Open Graph description meta tag within the head section of `trends.html`.

#### Details:
* **Current Behavior:** The `og:description` meta tag was left completely blank (`<meta property="og:description" content="">`), which could lead to missing or poor link previews when the page is shared on social media and messaging platforms.
* **Proposed Resolution:** Populated the `og:description` content attribute with the exact same summary string used in the standard page description ("Stay ahead with Furnix's interior design trends. Explore the latest in modern furniture styles, color palettes, and home decor inspirations.").