### PR TITLE
Refactor toast.js to enhance security

### DIFF
--- a/toast.js
+++ b/toast.js
@@ -25,15 +25,27 @@
     };
     const iconClass = iconMap[type] || 'fa-circle-info';
 
-    toast.innerHTML =
-      '<i class="fa-solid ' + iconClass + '" aria-hidden="true"></i>' +
-      '<span class="toast-message">' + message + '</span>' +
-      '<button class="toast-close" aria-label="Close notification">&times;</button>';
+    // Construct safe elements to prevent DOM-based XSS injection
+    const icon = document.createElement('i');
+    icon.className = 'fa-solid ' + iconClass;
+    icon.setAttribute('aria-hidden', 'true');
 
-    const closeBtn = toast.querySelector('.toast-close');
+    const messageSpan = document.createElement('span');
+    messageSpan.className = 'toast-message';
+    messageSpan.textContent = message; // Safely set text content instead of innerHTML
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'toast-close';
+    closeBtn.setAttribute('aria-label', 'Close notification');
+    closeBtn.innerHTML = '&times;';
+
     closeBtn.addEventListener('click', function() {
       dismiss(toast);
     });
+
+    toast.appendChild(icon);
+    toast.appendChild(messageSpan);
+    toast.appendChild(closeBtn);
 
     getContainer().appendChild(toast);
 


### PR DESCRIPTION
Refactor toast creation to use safe DOM elements and prevent XSS. ### Description
This pull request addresses issue [#596](https://github.com/janavipandole/Furnix/issues/596) ("security(toast): sanitize toast message text to prevent potential DOM-based XSS injection") in the [Furnix](https://github.com/janavipandole/Furnix) repository.

#### Details:
* **XSS Prevention:** Replaced vulnerable `innerHTML` interpolation of raw user messages with safe DOM manipulation (`textContent`).
* **Robust Text Insertion:** Created a dedicated `<span>` element using `document.createElement('span')` and assigned the message via `textContent`, ensuring that any HTML or script payloads passed to `showToast()` are safely escaped and rendered as plain text.