### PR TITLE
Add financing micro-calculator for BNPL pricing

### DIFF
--- a/Lighting.html
+++ b/Lighting.html
@@ -250,5 +250,6 @@
     <script src="app.js"></script>
     <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
+    <script src="scripts/financing-calculator.js"></script>
 </body>
 </html>

--- a/accessories.html
+++ b/accessories.html
@@ -244,5 +244,6 @@
     <script src="app.js"></script>
     <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
+    <script src="scripts/financing-calculator.js"></script>
 </body>
 </html>

--- a/furniture.html
+++ b/furniture.html
@@ -591,5 +591,6 @@
     <script src="app.js"></script>
     <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
+    <script src="scripts/financing-calculator.js"></script>
   </body>
 </html>

--- a/scripts/financing-calculator.js
+++ b/scripts/financing-calculator.js
@@ -1,0 +1,98 @@
+/**
+ * Furnix Financing Micro-Calculator
+ * Dynamically calculates and displays BNPL (Buy Now, Pay Later) installment pricing to reduce sticker shock.
+ */
+
+(function(global) {
+    'use strict';
+
+    class FinancingMicroCalculator {
+        /**
+         * @param {string} priceSelector - CSS selector for the main product price element
+         * @param {string} containerSelector - CSS selector for where to inject the badge
+         */
+        constructor(priceSelector, containerSelector) {
+            this.priceElement = document.querySelector(priceSelector);
+            this.container = document.querySelector(containerSelector);
+            
+            // Financing Terms Configuration
+            this.installments = 4;
+            this.provider = 'Klarna';
+
+            if (this.priceElement && this.container) {
+                this.init();
+            }
+        }
+
+        init() {
+            // Create the badge container
+            this.badge = document.createElement('div');
+            this.badge.className = 'financing-micro-calculator mt-2 text-muted small';
+            this.container.appendChild(this.badge);
+
+            // Initial render
+            this.updateBadge();
+
+            // Observe the price element for variant changes
+            const observer = new MutationObserver(() => this.updateBadge());
+            observer.observe(this.priceElement, { 
+                childList: true, 
+                characterData: true, 
+                subtree: true 
+            });
+        }
+
+        parsePrice(text) {
+            // Strip out currency symbols and commas to get the raw float
+            const cleaned = text.replace(/[^0-9.]/g, '');
+            return parseFloat(cleaned);
+        }
+
+        formatCurrency(value) {
+            return new Intl.NumberFormat('en-US', {
+                style: 'currency',
+                currency: 'USD',
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 2
+            }).format(value);
+        }
+
+        updateBadge() {
+            if (!this.priceElement) return;
+
+            const rawText = this.priceElement.innerText || this.priceElement.textContent;
+            const rawPrice = this.parsePrice(rawText);
+
+            if (isNaN(rawPrice) || rawPrice <= 0) {
+                this.badge.style.display = 'none';
+                return;
+            }
+
+            const installmentAmount = rawPrice / this.installments;
+            
+            const formattedTotal = this.formatCurrency(rawPrice);
+            const formattedInstallment = this.formatCurrency(installmentAmount);
+
+            this.badge.style.display = 'block';
+            this.badge.innerHTML = `
+                <div class="d-inline-flex align-items-center bg-light border rounded px-3 py-2 mt-1">
+                    <span class="me-2">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-dark"><rect width="20" height="14" x="2" y="5" rx="2"/><line x1="2" x2="22" y1="10" y2="10"/></svg>
+                    </span>
+                    <span>
+                        <strong>${formattedTotal}</strong> or ${this.installments} easy payments of <strong>${formattedInstallment}</strong> with <strong>${this.provider}</strong>.
+                    </span>
+                </div>
+            `;
+        }
+    }
+
+    global.FurnixFinancingCalculator = FinancingMicroCalculator;
+
+    // Auto-initialize on product detail pages (assuming standard class names are present)
+    document.addEventListener('DOMContentLoaded', () => {
+        // Adjust selectors to match the PDP HTML structure
+        new FinancingMicroCalculator('.product-price', '.price-container');
+    });
+
+})(typeof window !== 'undefined' ? window : this);

--- a/seating.html
+++ b/seating.html
@@ -253,5 +253,6 @@
     <script src="app.js"></script>
     <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
+    <script src="scripts/financing-calculator.js"></script>
 </body>
 </html>

--- a/tables.html
+++ b/tables.html
@@ -236,5 +236,6 @@
     <script src="app.js"></script>
     <script src="toast.js"></script>
     <script type="module" src="auth.js"></script>
+    <script src="scripts/financing-calculator.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This script implements a financing micro-calculator that dynamically calculates and displays BNPL installment pricing based on the product price.

## Description
This pull request introduces a dynamic Buy Now, Pay Later (BNPL) micro-calculator to help unblock high-ticket purchases and reduce sticker shock. It adds a new script (`financing-calculator.js`) that automatically computes and displays a 4-payment installment plan (via Klarna) directly below the main product price.

- Fixes #458

### Details:
* **Dynamic BNPL Calculation:** Parses the product's active price and computes 4 interest-free split payments.
* **Reactive DOM Observation:** Utilizes a `MutationObserver` to watch the main price element (`.product-price`). If the user selects a different variant and the price changes, the badge instantly recalculates the new monthly payment without requiring a page reload.
* **Conversion Optimization:** Injects a highly visible, confidence-building badge to improve conversion rates on high-ticket items.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Verified price parsing logic handles commas, currency symbols, and dynamic price updates correctly.
- [x] Tested `MutationObserver` functionality to ensure the badge updates seamlessly on variant changes without duplicate DOM injections.
- [x] Tested locally on desktop and mobile viewports for responsive badge rendering.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings