### PR TITLE
Implement shipping cost calculation engine

### DIFF
--- a/Furnix-main/shippingCalculator.js
+++ b/Furnix-main/shippingCalculator.js
@@ -1,0 +1,43 @@
+/**
+ * Furnix Shipping Calculation Engine
+ * Safely calculates shipping costs, enforcing LTL freight rates for oversized items.
+ */
+
+const STANDARD_SHIPPING_RATE = 15.00;
+const FREE_SHIPPING_THRESHOLD = 100.00; 
+const BASE_FREIGHT_RATE = 150.00;
+
+/**
+ * Calculates the final shipping cost based on cart contents and total value.
+ * 
+ * @param {Array} cartItems - Array of product objects currently in the cart
+ * @param {number} cartSubtotal - The total monetary value of the cart
+ * @returns {number} The calculated shipping cost
+ */
+export const calculateShippingCost = (cartItems, cartSubtotal) => {
+    if (!Array.isArray(cartItems) || cartItems.length === 0) {
+        return 0;
+    }
+
+    // 1. STRICT ALGORITHMIC GUARD CLAUSE
+    // Detect any item flagged for LTL freight based on SKU parameters
+    const requiresFreight = cartItems.some(item => 
+        item.is_freight === true || 
+        item.freight_class === 'LTL' ||
+        (item.dim_weight && item.dim_weight > 150) // Fallback check for heavy items
+    );
+
+    // 2. OVERRIDE: Apply Freight Rules
+    if (requiresFreight) {
+        // Here you could eventually wire up a real-time LTL API.
+        // For now, we inject the static heavy-freight tier to stop margin bleeding.
+        return BASE_FREIGHT_RATE;
+    }
+
+    // 3. STANDARD PARCEL LOGIC
+    if (cartSubtotal >= FREE_SHIPPING_THRESHOLD) {
+        return 0; // Free shipping promo applies
+    }
+
+    return STANDARD_SHIPPING_RATE;
+};

--- a/app.js
+++ b/app.js
@@ -182,6 +182,28 @@ function goToStep(step) {
   }
 }
 
+// --- LTL FREIGHT SHIPPING CALCULATOR (Issue #451 Fix) ---
+function calculateShippingCost(cartItems, subtotal, freeThreshold, defaultRate) {
+  const BASE_FREIGHT_RATE = 150.00;
+
+  // 1. STRICT ALGORITHMIC GUARD CLAUSE: Detect oversized items
+  const requiresFreight = cartItems.some(item => 
+      item.is_freight === true || 
+      item.freight_class === 'LTL' ||
+      (item.dim_weight && item.dim_weight > 150)
+  );
+
+  if (requiresFreight) {
+      return BASE_FREIGHT_RATE; // Protect margins on heavy items
+  }
+
+  // 2. STANDARD PARCEL LOGIC
+  if (subtotal >= freeThreshold) {
+      return 0; // Free shipping applies
+  }
+  return defaultRate;
+}
+
 function renderCartPage() {
   const listEl = document.getElementById("cartItemsList");
   if (!listEl) return;
@@ -293,7 +315,10 @@ function updateCartSummary() {
     (sum, item) => sum + item.price * (item.quantity || 1),
     0,
   );
-  const shipping = subtotal >= 500 ? 0 : 25;
+  
+  // ✅ FIXED: Freight calculator protects margins in Cart Summary
+  const shipping = calculateShippingCost(cart, subtotal, 500, 25);
+  
   const tax = subtotal * 0.08;
   const total = subtotal + shipping + tax;
 
@@ -331,7 +356,10 @@ function renderCheckoutSummary() {
     (sum, item) => sum + item.price * (item.quantity || 1),
     0,
   );
-  const shipping = subtotal >= 150 ? 0 : 15;
+  
+  // ✅ FIXED: Freight calculator protects margins in Checkout Summary
+  const shipping = calculateShippingCost(cart, subtotal, 150, 15);
+  
   const tax = subtotal * 0.1;
   const total = subtotal + shipping + tax;
 


### PR DESCRIPTION
This module calculates shipping costs based on cart contents, applying different rates for standard and freight shipping.

### Description
This pull request resolves Issue #451("Bug: Cart summary drastically miscalculates heavy-freight shipping costs, destroying profit margins") in the [Furnix](https://github.com/janavipandole/Furnix) repository.

#### Details:
* **Algorithmic Guard Clause:** Engineered a strict override in the shipping calculation engine. The system now scans the cart array for the `is_freight` or `freight_class` flags attached to product SKUs.
* **Freight Logic Injection:** If a heavy-freight item (like a sectional sofa) is detected, the frontend bypasses standard promotional logic (e.g., free shipping thresholds) and correctly applies a mandatory LTL (Less Than Truckload) freight base rate. 
* **Margin Protection:** Prevents the catastrophic scenario where expensive freight deliveries are erroneously charged at the $15 standard parcel rate, instantly restoring profit margins on high-ticket items.