### PR TITLE
feat(warranty): add extended warranty and care protection plan calculator engine

### DIFF
--- a/docs/CLIENT_API_REFERENCE.md
+++ b/docs/CLIENT_API_REFERENCE.md
@@ -131,3 +131,18 @@ Verifies voucher code eligibility against minimum order spend requirements.
 
 #### `calculateDiscount(code: string, subtotal: number): number`
 Calculates exact dollar discount savings for active coupon.
+
+---
+
+## 🛡️ 9. WarrantyProtectionPlanEngine (`scripts/warranty-protection-plan-engine.js`)
+
+Calculates tiered extended warranties and care protection plans with accidental damage coverage and category risk multipliers.
+
+### Methods
+
+#### `calculatePlanCost(itemPrice?: number, category?: string, planId?: string): Object`
+Calculates specific warranty plan cost, accidental damage terms, and aggregate product total.
+
+#### `getAvailablePlans(itemPrice?: number, category?: string): Array<Object>`
+Returns all supported plan options (1-Year, 2-Year, 3-Year, 5-Year) for a given catalog item.
+

--- a/scripts/warranty-protection-plan-engine.js
+++ b/scripts/warranty-protection-plan-engine.js
@@ -1,0 +1,92 @@
+/**
+ * Furnix Extended Warranty & Care Protection Plan Engine
+ * Calculates tiered protection plans (1-year, 3-year, 5-year) based on product category, replacement price, and accidental damage coverage.
+ */
+
+(function (global) {
+    'use strict';
+
+    const WarrantyProtectionPlanEngine = {
+        // Plan tier definitions with baseline coverage percentage
+        PLAN_TIERS: {
+            'none': { id: 'none', name: 'Standard 1-Year Manufacturer Warranty', years: 1, rate: 0.00, minFee: 0, includesAccidental: false },
+            'care-2yr': { id: 'care-2yr', name: '2-Year Extended Care Protection', years: 2, rate: 0.10, minFee: 29.00, includesAccidental: true },
+            'care-3yr': { id: 'care-3yr', name: '3-Year Premium Complete Protection', years: 3, rate: 0.16, minFee: 49.00, includesAccidental: true },
+            'care-5yr': { id: 'care-5yr', name: '5-Year Ultimate Heirloom Shield', years: 5, rate: 0.22, minFee: 89.00, includesAccidental: true }
+        },
+
+        // Category risk multiplier
+        CATEGORY_MULTIPLIERS: {
+            'Seating': 1.15,     // Sofas/chairs have higher fabric wear risk
+            'Tables': 1.00,      // Baseline
+            'Lighting': 0.90,    // Lower mechanical wear
+            'Accessories': 0.85, // Simple decor
+            'Storage': 1.00
+        },
+
+        /**
+         * Computes warranty plan cost and coverage details for an item.
+         * @param {number} itemPrice Product price in USD
+         * @param {string} category Product category
+         * @param {string} planId Selected plan tier key ('none', 'care-2yr', 'care-3yr', 'care-5yr')
+         * @returns {Object} Calculated plan details
+         */
+        calculatePlanCost(itemPrice = 0, category = 'Tables', planId = 'care-3yr') {
+            const price = Math.max(0, parseFloat(itemPrice) || 0);
+            const plan = this.PLAN_TIERS[planId] || this.PLAN_TIERS['none'];
+            const multiplier = this.CATEGORY_MULTIPLIERS[category] || 1.00;
+
+            if (plan.id === 'none' || price === 0) {
+                return {
+                    planId: plan.id,
+                    planName: plan.name,
+                    coverageYears: plan.years,
+                    planCost: 0,
+                    includesAccidental: false,
+                    totalWithWarranty: price,
+                    features: ['Manufacturer structural defects covered (1 year)']
+                };
+            }
+
+            const rawCost = (price * plan.rate) * multiplier;
+            const finalCost = Math.round(Math.max(plan.minFee, rawCost) * 100) / 100;
+            const totalWithWarranty = Math.round((price + finalCost) * 100) / 100;
+
+            const features = [
+                `Full ${plan.years}-Year structural & mechanical coverage`,
+                'Accidental stain, scratch & rip protection',
+                'Zero deductible with in-home repair or replacement',
+                '24/7 Priority support concierge'
+            ];
+
+            return {
+                planId: plan.id,
+                planName: plan.name,
+                coverageYears: plan.years,
+                planCost: finalCost,
+                includesAccidental: plan.includesAccidental,
+                categoryMultiplier: multiplier,
+                totalWithWarranty: totalWithWarranty,
+                features: features
+            };
+        },
+
+        /**
+         * Returns all available protection plan options for product configuration.
+         * @param {number} itemPrice 
+         * @param {string} category 
+         * @returns {Array<Object>}
+         */
+        getAvailablePlans(itemPrice = 0, category = 'Tables') {
+            return Object.keys(this.PLAN_TIERS).map(planKey => {
+                return this.calculatePlanCost(itemPrice, category, planKey);
+            });
+        }
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = WarrantyProtectionPlanEngine;
+    } else {
+        global.WarrantyProtectionPlanEngine = WarrantyProtectionPlanEngine;
+    }
+})(typeof window !== 'undefined' ? window : this);

--- a/scripts/warranty-protection-plan-engine.test.js
+++ b/scripts/warranty-protection-plan-engine.test.js
@@ -1,0 +1,44 @@
+/**
+ * Unit Test Suite for Extended Warranty & Protection Plan Engine
+ * Run with: node scripts/warranty-protection-plan-engine.test.js
+ */
+
+const assert = require('assert');
+const WarrantyProtectionPlanEngine = require('./warranty-protection-plan-engine');
+
+console.log('🧪 Running WarrantyProtectionPlanEngine Tests...');
+
+// Test 1: Standard 'none' option gives $0 cost
+const nonePlan = WarrantyProtectionPlanEngine.calculatePlanCost(500, 'Tables', 'none');
+assert.strictEqual(nonePlan.planCost, 0);
+assert.strictEqual(nonePlan.coverageYears, 1);
+assert.strictEqual(nonePlan.totalWithWarranty, 500);
+console.log('  ✔ Test 1 passed: Standard baseline manufacturer warranty handled accurately.');
+
+// Test 2: 3-Year plan for standard Table ($500 * 0.16 * 1.0 = $80.00)
+const tablePlan = WarrantyProtectionPlanEngine.calculatePlanCost(500, 'Tables', 'care-3yr');
+assert.strictEqual(tablePlan.planCost, 80.00);
+assert.strictEqual(tablePlan.coverageYears, 3);
+assert.strictEqual(tablePlan.includesAccidental, true);
+assert.strictEqual(tablePlan.totalWithWarranty, 580.00);
+console.log('  ✔ Test 2 passed: 3-Year Table protection plan cost computed accurately.');
+
+// Test 3: Category multiplier for Seating ($600 * 0.16 * 1.15 = 110.40)
+const sofaPlan = WarrantyProtectionPlanEngine.calculatePlanCost(600, 'Seating', 'care-3yr');
+assert.strictEqual(sofaPlan.planCost, 110.40);
+assert.strictEqual(sofaPlan.categoryMultiplier, 1.15);
+console.log('  ✔ Test 3 passed: Seating category risk multiplier applied correctly.');
+
+// Test 4: Minimum plan fee enforcement ($50 item on 2yr plan min fee $29)
+const minFeePlan = WarrantyProtectionPlanEngine.calculatePlanCost(50, 'Lighting', 'care-2yr');
+assert.strictEqual(minFeePlan.planCost, 29.00);
+console.log('  ✔ Test 4 passed: Minimum plan floor fee enforced for low-cost items.');
+
+// Test 5: List all available plan tiers
+const allPlans = WarrantyProtectionPlanEngine.getAvailablePlans(400, 'Tables');
+assert.strictEqual(allPlans.length, 4);
+assert.strictEqual(allPlans[0].planId, 'none');
+assert.strictEqual(allPlans[1].planId, 'care-2yr');
+console.log('  ✔ Test 5 passed: All tier options queried correctly.');
+
+console.log('🎉 All WarrantyProtectionPlanEngine tests passed successfully!\n');

--- a/submissions/warranty-protection-plan-demo.html
+++ b/submissions/warranty-protection-plan-demo.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Furnix - Extended Warranty & Care Protection Plan Demo</title>
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="warranty-protection-plan.css">
+</head>
+<body style="background: #f8fafc; padding: 20px;">
+    <div class="warranty-demo-container">
+        <div class="warranty-demo-header">
+            <h2 style="margin: 0 0 6px 0; font-size: 24px;">Furnix Care Protection Plan Calculator Sandbox</h2>
+            <p style="margin: 0; color: #6b7280; font-size: 14px;">Select product categories and pricing to compute tier protection plans and accidental damage coverage.</p>
+        </div>
+
+        <div class="product-config-strip">
+            <div class="config-item">
+                <label for="prod-category">Product Category</label>
+                <select id="prod-category">
+                    <option value="Seating">Seating (Sofas / Chairs) - Higher Wear</option>
+                    <option value="Tables" selected>Tables & Desks</option>
+                    <option value="Lighting">Lighting & Fixtures</option>
+                    <option value="Storage">Storage & Shelving</option>
+                    <option value="Accessories">Home Accessories</option>
+                </select>
+            </div>
+            <div class="config-item">
+                <label for="prod-price">Product Price ($)</label>
+                <input type="number" id="prod-price" value="550" step="50">
+            </div>
+        </div>
+
+        <h3 style="font-size: 16px; margin-bottom: 14px;">Choose a Care Protection Plan:</h3>
+        <div class="plans-grid" id="plans-container">
+            <!-- Dynamically populated plan cards -->
+        </div>
+
+        <div class="total-summary-card">
+            <div>
+                <span style="font-size: 13px; color: #94a3b8; text-transform: uppercase;">Selected Plan</span>
+                <h4 id="selected-plan-name" style="margin: 4px 0 0 0; font-size: 16px;">3-Year Premium Complete Protection</h4>
+            </div>
+            <div style="text-align: right;">
+                <span style="font-size: 13px; color: #94a3b8; text-transform: uppercase;">Total with Protection</span>
+                <div id="selected-total-price" style="font-size: 24px; font-weight: 800; color: #38bdf8;">$638.00</div>
+            </div>
+        </div>
+    </div>
+
+    <script src="../scripts/warranty-protection-plan-engine.js"></script>
+    <script>
+        let currentSelectedPlan = 'care-3yr';
+
+        function renderPlans() {
+            const category = document.getElementById('prod-category').value;
+            const price = parseFloat(document.getElementById('prod-price').value) || 0;
+            const plans = WarrantyProtectionPlanEngine.getAvailablePlans(price, category);
+            const container = document.getElementById('plans-container');
+            container.innerHTML = '';
+
+            plans.forEach(plan => {
+                const isSelected = plan.planId === currentSelectedPlan;
+                const card = document.createElement('div');
+                card.className = `plan-card ${isSelected ? 'selected' : ''}`;
+                if (plan.planId === 'care-3yr') {
+                    card.innerHTML += '<div class="plan-badge">Most Popular</div>';
+                }
+                card.innerHTML += `
+                    <div class="plan-title">${plan.planName}</div>
+                    <div class="plan-price">${plan.planCost === 0 ? 'FREE' : '+$' + plan.planCost.toFixed(2)}</div>
+                    <ul class="plan-features-list">
+                        ${plan.features.map(f => `<li>✔ ${f}</li>`).join('')}
+                    </ul>
+                `;
+                card.onclick = () => {
+                    currentSelectedPlan = plan.planId;
+                    renderPlans();
+                };
+                container.appendChild(card);
+
+                if (isSelected) {
+                    document.getElementById('selected-plan-name').textContent = plan.planName;
+                    document.getElementById('selected-total-price').textContent = `$${plan.totalWithWarranty.toFixed(2)}`;
+                }
+            });
+        }
+
+        document.getElementById('prod-category').addEventListener('change', renderPlans);
+        document.getElementById('prod-price').addEventListener('input', renderPlans);
+
+        renderPlans();
+    </script>
+</body>
+</html>

--- a/submissions/warranty-protection-plan.css
+++ b/submissions/warranty-protection-plan.css
@@ -1,0 +1,127 @@
+/* Submissions Warranty Protection Plan Demo Styles */
+.warranty-demo-container {
+    max-width: 860px;
+    margin: 40px auto;
+    padding: 30px;
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.06);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    color: #1a1a1a;
+}
+
+.warranty-demo-header {
+    border-bottom: 2px solid #f1f3f5;
+    padding-bottom: 16px;
+    margin-bottom: 24px;
+}
+
+.product-config-strip {
+    display: flex;
+    gap: 16px;
+    background: #f8fafc;
+    padding: 16px;
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+    margin-bottom: 24px;
+}
+
+.config-item {
+    flex: 1;
+}
+
+.config-item label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: #475569;
+}
+
+.config-item select,
+.config-item input {
+    width: 100%;
+    padding: 8px 12px;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+.plans-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+}
+
+.plan-card {
+    border: 2px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 20px;
+    cursor: pointer;
+    transition: all 0.2s;
+    position: relative;
+    background: #ffffff;
+}
+
+.plan-card:hover {
+    border-color: #94a3b8;
+}
+
+.plan-card.selected {
+    border-color: #2563eb;
+    background: #eff6ff;
+    box-shadow: 0 4px 12px rgba(37,99,235,0.1);
+}
+
+.plan-badge {
+    position: absolute;
+    top: -10px;
+    right: 14px;
+    background: #2563eb;
+    color: #ffffff;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 12px;
+    text-transform: uppercase;
+}
+
+.plan-title {
+    font-size: 16px;
+    font-weight: 700;
+    margin: 0 0 8px 0;
+}
+
+.plan-price {
+    font-size: 20px;
+    font-weight: 800;
+    color: #0f172a;
+    margin-bottom: 12px;
+}
+
+.plan-features-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 12px;
+    color: #64748b;
+}
+
+.plan-features-list li {
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.total-summary-card {
+    margin-top: 24px;
+    background: #0f172a;
+    color: #ffffff;
+    padding: 20px;
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}


### PR DESCRIPTION
# Related Issue
Closes #757

Implement Extended Warranty and Care Protection Plan Calculator Engine with Category Risk Multipliers

# Summary
Implements `WarrantyProtectionPlanEngine` to calculate tiered extended warranties (2-Year, 3-Year, 5-Year) with accidental damage terms, minimum plan fees, and category wear risk multipliers.

# Changes Made
- Added `scripts/warranty-protection-plan-engine.js` providing tiered warranty calculations and plan queries.
- Added comprehensive unit tests in `scripts/warranty-protection-plan-engine.test.js`.
- Created interactive sandbox demo in `submissions/warranty-protection-plan-demo.html` and `submissions/warranty-protection-plan.css`.
- Documented module API in `docs/CLIENT_API_REFERENCE.md`.

# Testing
- Ran unit tests: `node scripts/warranty-protection-plan-engine.test.js` (5/5 tests passed).
- Verified environment diagnostics: `node scripts/dev-environment-check.js` (PASSED).
- Verified plan tier selection and aggregate price updates in the sandbox UI.

# Impact
Enables customer-facing care and warranty protection plans across product categories.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
